### PR TITLE
Add directory access guards for PHP-only folders

### DIFF
--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,0 +1,6 @@
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/config/.htaccess
+++ b/config/.htaccess
@@ -1,0 +1,6 @@
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/templates/.htaccess
+++ b/templates/.htaccess
@@ -1,0 +1,6 @@
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>


### PR DESCRIPTION
## Summary
- deny direct HTTP access within config/, app/, and templates/ by adding protective .htaccess rules
- ensure sensitive PHP-only directories cannot be browsed or downloaded directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d9d47464188325ad2e003ab87b8268