### PR TITLE
Add Lotus Licenses WooCommerce storefront theme

### DIFF
--- a/wordpress-theme/README.md
+++ b/wordpress-theme/README.md
@@ -1,0 +1,21 @@
+# Lotus Licenses WooCommerce Theme
+
+This directory contains a bespoke WordPress theme inspired by the Lotus Lisans storefront. The theme is engineered for software license resellers who require stunning landing pages, SEO-friendly markup, and deep WooCommerce integration.
+
+## Key Features
+- Conversion-driven front page with hero, features, product grid, testimonials, and CTA sections.
+- Automatic plugin bootstrapper that installs/activates WooCommerce, Elementor, Contact Form 7, and Yoast SEO when the theme is enabled.
+- Fully responsive layout powered by Plus Jakarta Sans typography and modern gradient styling.
+- Translation-ready strings and Customizer controls for hero content and highlight metrics.
+- Tailored WooCommerce styling with featured product cards and CTA-driven merchandising.
+
+## Installation
+1. Copy the `lotus-licenses` folder into your WordPress installation under `wp-content/themes/`.
+2. Activate the theme via **Appearance → Themes**. On activation, the theme will attempt to install and activate the recommended plugins.
+3. Set the **Homepage** to use the "Front page" template under **Settings → Reading**.
+4. Customize the hero copy, CTA text, and highlight metrics in the WordPress Customizer.
+
+## Development Notes
+- Global styles live in `style.css`, while presentation layers are in `assets/css/theme.css`.
+- JavaScript enhancements (sticky header, testimonial carousel) live in `assets/js/theme.js`.
+- Template partials reside in `template-parts/` and can be modified to fit additional marketing sections.

--- a/wordpress-theme/lotus-licenses/archive.php
+++ b/wordpress-theme/lotus-licenses/archive.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Archive template.
+ *
+ * @package Lotus_Licenses
+ */
+
+get_header();
+?>
+<div class="site-container content-area">
+    <header class="archive-header">
+        <?php the_archive_title( '<h1 class="archive-title">', '</h1>' ); ?>
+        <?php the_archive_description( '<div class="archive-description">', '</div>' ); ?>
+    </header>
+    <?php if ( have_posts() ) : ?>
+        <div class="archive-grid">
+            <?php while ( have_posts() ) : the_post(); ?>
+                <article id="post-<?php the_ID(); ?>" <?php post_class( 'entry entry--archive' ); ?>>
+                    <?php if ( has_post_thumbnail() ) : ?>
+                        <div class="entry__media">
+                            <a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'medium_large' ); ?></a>
+                        </div>
+                    <?php endif; ?>
+                    <header class="entry__header">
+                        <?php the_title( '<h2 class="entry__title">', '</h2>' ); ?>
+                    </header>
+                    <div class="entry__content">
+                        <?php the_excerpt(); ?>
+                    </div>
+                    <footer class="entry__footer">
+                        <a class="button button--ghost" href="<?php the_permalink(); ?>"><?php esc_html_e( 'Read more', 'lotus-licenses' ); ?></a>
+                    </footer>
+                </article>
+            <?php endwhile; ?>
+        </div>
+        <div class="pagination">
+            <?php the_posts_pagination(); ?>
+        </div>
+    <?php else : ?>
+        <p><?php esc_html_e( 'There is no content to display yet. Publish posts or products to populate this feed.', 'lotus-licenses' ); ?></p>
+    <?php endif; ?>
+</div>
+<?php
+get_footer();

--- a/wordpress-theme/lotus-licenses/assets/css/theme.css
+++ b/wordpress-theme/lotus-licenses/assets/css/theme.css
@@ -1,0 +1,427 @@
+/*
+ * Lotus Licenses presentation layer.
+ */
+
+body {
+    background: var(--lotus-background);
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.8rem;
+    border-radius: 999px;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: transform var(--lotus-transition), box-shadow var(--lotus-transition);
+}
+
+.button--primary {
+    color: #fff;
+    background: linear-gradient(135deg, var(--lotus-secondary), var(--lotus-primary));
+    box-shadow: var(--lotus-shadow-sm);
+}
+
+.button--primary:hover,
+.button--primary:focus {
+    box-shadow: var(--lotus-shadow-md);
+    transform: translateY(-2px);
+}
+
+.button--ghost {
+    color: var(--lotus-primary);
+    background: transparent;
+    border: 1px solid rgba(63, 55, 201, 0.25);
+}
+
+.button--ghost:hover,
+.button--ghost:focus {
+    border-color: var(--lotus-primary);
+    color: var(--lotus-primary-dark);
+}
+
+.site-header__cta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.site-header__cta-link {
+    font-weight: 600;
+    color: var(--lotus-text);
+    padding: 0.55rem 1.25rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    transition: background var(--lotus-transition), color var(--lotus-transition), border var(--lotus-transition);
+}
+
+.site-header__cta-link:hover,
+.site-header__cta-link:focus {
+    color: var(--lotus-primary);
+    border-color: rgba(63, 55, 201, 0.25);
+}
+
+.site-header__cta-link--primary {
+    background: linear-gradient(135deg, var(--lotus-secondary), var(--lotus-primary));
+    color: #fff;
+}
+
+.site-header__cta-link--primary:hover,
+.site-header__cta-link--primary:focus {
+    color: #fff;
+    box-shadow: var(--lotus-shadow-sm);
+}
+
+.lotus-front-page {
+    display: flex;
+    flex-direction: column;
+    gap: 6rem;
+    padding-bottom: 6rem;
+}
+
+.lotus-hero {
+    position: relative;
+    padding: 6rem 0 4rem;
+    background: radial-gradient(circle at top left, rgba(67, 97, 238, 0.18), transparent 55%),
+        linear-gradient(160deg, rgba(63, 55, 201, 0.12), rgba(76, 201, 240, 0.08));
+}
+
+.lotus-hero__inner {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 3rem;
+    align-items: center;
+}
+
+.lotus-hero__eyebrow {
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--lotus-secondary-dark);
+    margin-bottom: 1rem;
+}
+
+.lotus-hero__headline {
+    font-size: clamp(2.5rem, 4vw, 3.4rem);
+    line-height: 1.1;
+    margin: 0 0 1.5rem;
+}
+
+.lotus-hero__subheadline {
+    font-size: 1.1rem;
+    color: var(--lotus-muted);
+    max-width: 520px;
+    margin-bottom: 2rem;
+}
+
+.lotus-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.lotus-hero__metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.5rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    color: var(--lotus-muted);
+}
+
+.lotus-hero__media {
+    display: flex;
+    justify-content: center;
+}
+
+.lotus-hero__card {
+    background: #fff;
+    border-radius: var(--lotus-radius-lg);
+    padding: 2.5rem;
+    box-shadow: var(--lotus-shadow-lg);
+    max-width: 380px;
+}
+
+.lotus-hero__card ul {
+    padding: 0;
+    margin: 1.5rem 0 0;
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+    color: var(--lotus-text);
+}
+
+.lotus-hero__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.45rem 1.1rem;
+    border-radius: 999px;
+    background: rgba(247, 37, 133, 0.12);
+    color: var(--lotus-danger);
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.lotus-section {
+    position: relative;
+}
+
+.lotus-section--features {
+    padding: 0 0 4rem;
+}
+
+.lotus-section__heading {
+    max-width: 760px;
+    margin: 0 auto 3rem;
+    text-align: center;
+}
+
+.lotus-section__eyebrow {
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--lotus-secondary-dark);
+    display: block;
+    margin-bottom: 0.75rem;
+}
+
+.lotus-feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 2rem;
+}
+
+.lotus-feature-card {
+    background: #fff;
+    border-radius: var(--lotus-radius-md);
+    padding: 2rem;
+    box-shadow: var(--lotus-shadow-sm);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.lotus-feature-card__icon {
+    font-size: 1.75rem;
+}
+
+.lotus-section--products {
+    padding: 0 0 4rem;
+}
+
+.lotus-product-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2rem;
+}
+
+.lotus-product-card {
+    background: #fff;
+    border-radius: var(--lotus-radius-md);
+    box-shadow: var(--lotus-shadow-sm);
+    transition: transform var(--lotus-transition), box-shadow var(--lotus-transition);
+}
+
+.lotus-product-card:hover,
+.lotus-product-card:focus-within {
+    transform: translateY(-6px);
+    box-shadow: var(--lotus-shadow-md);
+}
+
+.lotus-product-card__link {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 2rem;
+    color: inherit;
+}
+
+.lotus-product-card__badge {
+    align-self: flex-start;
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(64, 224, 208, 0.18);
+    color: var(--lotus-primary-dark);
+    font-size: 0.8rem;
+    font-weight: 700;
+}
+
+.lotus-product-card__meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.lotus-product-card__price {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--lotus-primary);
+}
+
+.lotus-product-placeholder {
+    text-align: center;
+    background: rgba(63, 55, 201, 0.08);
+    border-radius: var(--lotus-radius-md);
+    padding: 3rem;
+}
+
+.lotus-section--testimonials {
+    padding: 0 0 4rem;
+}
+
+.lotus-testimonial-carousel {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2rem;
+}
+
+.lotus-testimonial {
+    background: #fff;
+    border-radius: var(--lotus-radius-md);
+    padding: 2.5rem;
+    box-shadow: var(--lotus-shadow-sm);
+    position: relative;
+}
+
+.lotus-testimonial blockquote {
+    margin: 0;
+    font-size: 1.05rem;
+    color: var(--lotus-text);
+}
+
+.lotus-testimonial__meta {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    color: var(--lotus-muted);
+}
+
+.lotus-section--cta {
+    padding: 0 0 4rem;
+}
+
+.lotus-cta {
+    background: linear-gradient(130deg, rgba(63, 55, 201, 0.92), rgba(76, 201, 240, 0.85));
+    border-radius: var(--lotus-radius-lg);
+    padding: 3rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 2rem;
+    color: #fff;
+    box-shadow: var(--lotus-shadow-lg);
+}
+
+.lotus-cta__actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.lotus-cta .button--ghost {
+    border-color: rgba(255, 255, 255, 0.5);
+    color: #fff;
+}
+
+.lotus-cta .button--ghost:hover,
+.lotus-cta .button--ghost:focus {
+    border-color: #fff;
+}
+
+.content-area {
+    padding: 4rem 0;
+    display: grid;
+    gap: 2rem;
+}
+
+.entry {
+    background: #fff;
+    border-radius: var(--lotus-radius-md);
+    padding: 2.5rem;
+    box-shadow: var(--lotus-shadow-sm);
+}
+
+.entry__title {
+    margin: 0 0 1rem;
+    font-size: clamp(2rem, 3vw, 2.4rem);
+}
+
+.entry__meta {
+    display: flex;
+    gap: 1.5rem;
+    color: var(--lotus-muted);
+    font-size: 0.9rem;
+}
+
+.entry__content {
+    color: var(--lotus-text);
+}
+
+.entry__footer {
+    margin-top: 2rem;
+}
+
+.pagination {
+    display: flex;
+    justify-content: center;
+}
+
+.archive-grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.widget-area--footer {
+    display: grid;
+    gap: 1rem;
+}
+
+@media (max-width: 768px) {
+    .lotus-front-page {
+        gap: 4rem;
+    }
+
+    .site-header__cta {
+        width: 100%;
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+
+    .site-header__inner {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .lotus-hero__actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .lotus-cta {
+        text-align: center;
+    }
+
+    .lotus-cta__actions {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 540px) {
+    .lotus-hero {
+        padding-top: 4rem;
+    }
+
+    .lotus-hero__card {
+        padding: 2rem;
+    }
+}

--- a/wordpress-theme/lotus-licenses/assets/js/theme.js
+++ b/wordpress-theme/lotus-licenses/assets/js/theme.js
@@ -1,0 +1,42 @@
+(function ($) {
+    'use strict';
+
+    const body = document.body;
+
+    body.classList.add('lotus-js-enabled');
+
+    const carousel = document.querySelector('[data-behavior="testimonial-slider"]');
+    if (carousel) {
+        let currentIndex = 0;
+        const slides = Array.from(carousel.children);
+
+        function showSlide(index) {
+            slides.forEach((slide, idx) => {
+                slide.style.opacity = idx === index ? '1' : '0.25';
+                slide.style.transform = idx === index ? 'translateY(0)' : 'translateY(12px)';
+            });
+        }
+
+        function cycle() {
+            currentIndex = (currentIndex + 1) % slides.length;
+            showSlide(currentIndex);
+        }
+
+        showSlide(currentIndex);
+        setInterval(cycle, 6500);
+    }
+
+    const header = document.querySelector('.site-header');
+    if (header) {
+        let lastScrollY = window.scrollY;
+        window.addEventListener('scroll', () => {
+            const direction = window.scrollY > lastScrollY ? 'down' : 'up';
+            lastScrollY = window.scrollY;
+            if (direction === 'down' && window.scrollY > 120) {
+                header.classList.add('site-header--hidden');
+            } else {
+                header.classList.remove('site-header--hidden');
+            }
+        });
+    }
+})(jQuery);

--- a/wordpress-theme/lotus-licenses/footer.php
+++ b/wordpress-theme/lotus-licenses/footer.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Theme footer.
+ *
+ * @package Lotus_Licenses
+ */
+?>
+</main>
+<footer class="site-footer">
+    <div class="site-container">
+        <div class="site-footer__grid">
+            <div class="site-footer__brand">
+                <div class="site-footer__logo"><?php bloginfo( 'name' ); ?></div>
+                <?php $description = get_bloginfo( 'description', 'display' ); ?>
+                <?php if ( $description ) : ?>
+                    <p><?php echo esc_html( $description ); ?></p>
+                <?php endif; ?>
+                <p><?php esc_html_e( 'Delivering premium license fulfillment with automated workflows, instant digital delivery, and bulletproof customer support.', 'lotus-licenses' ); ?></p>
+            </div>
+            <div class="site-footer__menu">
+                <h3><?php esc_html_e( 'Quick Links', 'lotus-licenses' ); ?></h3>
+                <?php
+                wp_nav_menu(
+                    [
+                        'theme_location' => 'footer',
+                        'container'      => false,
+                        'fallback_cb'    => 'lotus_licenses_menu_fallback',
+                    ]
+                );
+                ?>
+            </div>
+            <div class="site-footer__widgets">
+                <?php if ( is_active_sidebar( 'footer-1' ) || is_active_sidebar( 'footer-2' ) || is_active_sidebar( 'footer-3' ) ) : ?>
+                    <div class="widget-area widget-area--footer">
+                        <?php dynamic_sidebar( 'footer-1' ); ?>
+                        <?php dynamic_sidebar( 'footer-2' ); ?>
+                        <?php dynamic_sidebar( 'footer-3' ); ?>
+                    </div>
+                <?php else : ?>
+                    <p><?php esc_html_e( 'Add widgets to the footer columns to personalize your trust signals and contact details.', 'lotus-licenses' ); ?></p>
+                <?php endif; ?>
+            </div>
+            <div class="site-footer__cta">
+                <h3><?php esc_html_e( 'Need a tailored plan?', 'lotus-licenses' ); ?></h3>
+                <p><?php esc_html_e( 'Our specialists craft bespoke reseller programs with automated billing, SLA-backed support, and enterprise analytics.', 'lotus-licenses' ); ?></p>
+                <a href="<?php echo esc_url( site_url( '/contact' ) ); ?>">
+                    <?php esc_html_e( 'Book a discovery call', 'lotus-licenses' ); ?>
+                </a>
+            </div>
+        </div>
+        <div class="site-footer__bottom">
+            <span>&copy; <?php echo esc_html( date_i18n( 'Y' ) ); ?> <?php echo esc_html( get_bloginfo( 'name' ) ); ?>. <?php esc_html_e( 'All rights reserved.', 'lotus-licenses' ); ?></span>
+            <span><?php esc_html_e( 'Crafted for WooCommerce excellence • PCI-DSS ready • GDPR compliant', 'lotus-licenses' ); ?></span>
+        </div>
+    </div>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/wordpress-theme/lotus-licenses/front-page.php
+++ b/wordpress-theme/lotus-licenses/front-page.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Front page template.
+ *
+ * @package Lotus_Licenses
+ */
+
+get_header();
+?>
+<div class="lotus-front-page">
+    <?php get_template_part( 'template-parts/hero' ); ?>
+    <?php get_template_part( 'template-parts/features' ); ?>
+    <?php get_template_part( 'template-parts/product-showcase' ); ?>
+    <?php get_template_part( 'template-parts/testimonials' ); ?>
+    <?php get_template_part( 'template-parts/cta' ); ?>
+</div>
+<?php
+get_footer();

--- a/wordpress-theme/lotus-licenses/functions.php
+++ b/wordpress-theme/lotus-licenses/functions.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Lotus Licenses theme bootstrap.
+ *
+ * @package Lotus_Licenses
+ */
+
+define( 'LOTUS_LICENSES_VERSION', '1.0.0' );
+
+define( 'LOTUS_LICENSES_PATH', trailingslashit( get_template_directory() ) );
+
+define( 'LOTUS_LICENSES_URI', trailingslashit( get_template_directory_uri() ) );
+
+require_once LOTUS_LICENSES_PATH . 'inc/setup.php';
+require_once LOTUS_LICENSES_PATH . 'inc/enqueue.php';
+require_once LOTUS_LICENSES_PATH . 'inc/customizer.php';
+require_once LOTUS_LICENSES_PATH . 'inc/template-tags.php';
+require_once LOTUS_LICENSES_PATH . 'inc/tgmpa.php';
+

--- a/wordpress-theme/lotus-licenses/header.php
+++ b/wordpress-theme/lotus-licenses/header.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Theme header.
+ *
+ * @package Lotus_Licenses
+ */
+?><!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<header class="site-header">
+    <div class="site-container site-header__inner">
+        <div class="site-branding">
+            <?php if ( has_custom_logo() ) : ?>
+                <div class="site-logo">
+                    <?php the_custom_logo(); ?>
+                </div>
+            <?php else : ?>
+                <a class="site-title" href="<?php echo esc_url( home_url( '/' ) ); ?>">
+                    <?php echo esc_html( get_bloginfo( 'name' ) ); ?>
+                </a>
+            <?php endif; ?>
+            <?php $description = get_bloginfo( 'description', 'display' ); ?>
+            <?php if ( $description ) : ?>
+                <p class="site-description"><?php echo esc_html( $description ); ?></p>
+            <?php endif; ?>
+        </div>
+        <nav class="site-navigation" aria-label="<?php esc_attr_e( 'Primary navigation', 'lotus-licenses' ); ?>">
+            <?php
+            wp_nav_menu(
+                [
+                    'theme_location' => 'primary',
+                    'menu_class'     => 'primary-menu',
+                    'container'      => false,
+                    'fallback_cb'    => 'lotus_licenses_menu_fallback',
+                ]
+            );
+            ?>
+        </nav>
+        <div class="site-header__cta">
+            <?php if ( class_exists( 'WooCommerce' ) && function_exists( 'wc_get_cart_url' ) ) : ?>
+                <a class="site-header__cta-link" href="<?php echo esc_url( wc_get_cart_url() ); ?>">
+                    <?php esc_html_e( 'View Cart', 'lotus-licenses' ); ?>
+                </a>
+            <?php endif; ?>
+            <?php $cta_url = get_theme_mod( 'lotus_licenses_hero_primary_url', function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'shop' ) : home_url( '/shop' ) ); ?>
+            <a class="site-header__cta-link site-header__cta-link--primary" href="<?php echo esc_url( $cta_url ); ?>">
+                <?php echo esc_html( get_theme_mod( 'lotus_licenses_hero_primary_label', __( 'Explore Products', 'lotus-licenses' ) ) ); ?>
+            </a>
+        </div>
+    </div>
+</header>
+<main id="content" class="site-main">

--- a/wordpress-theme/lotus-licenses/inc/customizer.php
+++ b/wordpress-theme/lotus-licenses/inc/customizer.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Customizer configuration.
+ *
+ * @package Lotus_Licenses
+ */
+
+if ( ! function_exists( 'lotus_licenses_customize_register' ) ) {
+    /**
+     * Register customizer panels and settings.
+     *
+     * @param WP_Customize_Manager $wp_customize Manager instance.
+     */
+    function lotus_licenses_customize_register( $wp_customize ) {
+        $wp_customize->add_section(
+            'lotus_licenses_hero',
+            [
+                'title'       => __( 'Hero Section', 'lotus-licenses' ),
+                'description' => __( 'Control the primary hero area displayed on the front page.', 'lotus-licenses' ),
+                'priority'    => 30,
+            ]
+        );
+
+        $wp_customize->add_setting(
+            'lotus_licenses_hero_headline',
+            [
+                'default'           => __( 'Enterprise-Grade License Automation', 'lotus-licenses' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ]
+        );
+
+        $wp_customize->add_control(
+            'lotus_licenses_hero_headline',
+            [
+                'label'       => __( 'Headline', 'lotus-licenses' ),
+                'section'     => 'lotus_licenses_hero',
+                'type'        => 'text',
+            ]
+        );
+
+        $wp_customize->add_setting(
+            'lotus_licenses_hero_subheadline',
+            [
+                'default'           => __( 'Launch a dazzling storefront that syncs your digital licenses in real time and converts visitors into lifelong customers.', 'lotus-licenses' ),
+                'sanitize_callback' => 'sanitize_textarea_field',
+            ]
+        );
+
+        $wp_customize->add_control(
+            'lotus_licenses_hero_subheadline',
+            [
+                'label'   => __( 'Subheadline', 'lotus-licenses' ),
+                'section' => 'lotus_licenses_hero',
+                'type'    => 'textarea',
+            ]
+        );
+
+        $wp_customize->add_setting(
+            'lotus_licenses_hero_primary_label',
+            [
+                'default'           => __( 'Explore Products', 'lotus-licenses' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ]
+        );
+
+        $wp_customize->add_control(
+            'lotus_licenses_hero_primary_label',
+            [
+                'label'   => __( 'Primary Button Label', 'lotus-licenses' ),
+                'section' => 'lotus_licenses_hero',
+                'type'    => 'text',
+            ]
+        );
+
+        $shop_url = function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'shop' ) : home_url( '/shop' );
+
+        $wp_customize->add_setting(
+            'lotus_licenses_hero_primary_url',
+            [
+                'default'           => $shop_url,
+                'sanitize_callback' => 'esc_url_raw',
+            ]
+        );
+
+        $wp_customize->add_control(
+            'lotus_licenses_hero_primary_url',
+            [
+                'label'   => __( 'Primary Button URL', 'lotus-licenses' ),
+                'section' => 'lotus_licenses_hero',
+                'type'    => 'url',
+            ]
+        );
+
+        $wp_customize->add_setting(
+            'lotus_licenses_highlight_metrics',
+            [
+                'default'           => __( '24/7 Automated Fulfilment • Fraud Screening • Reseller API • Instant Key Delivery', 'lotus-licenses' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ]
+        );
+
+        $wp_customize->add_control(
+            'lotus_licenses_highlight_metrics',
+            [
+                'label'       => __( 'Hero Highlights', 'lotus-licenses' ),
+                'description' => __( 'Separate multiple highlights with a bullet (•).', 'lotus-licenses' ),
+                'section'     => 'lotus_licenses_hero',
+                'type'        => 'text',
+            ]
+        );
+    }
+}
+add_action( 'customize_register', 'lotus_licenses_customize_register' );

--- a/wordpress-theme/lotus-licenses/inc/enqueue.php
+++ b/wordpress-theme/lotus-licenses/inc/enqueue.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Scripts and styles.
+ *
+ * @package Lotus_Licenses
+ */
+
+if ( ! function_exists( 'lotus_licenses_scripts' ) ) {
+    /**
+     * Enqueue front-end assets.
+     */
+    function lotus_licenses_scripts() {
+        wp_enqueue_style(
+            'lotus-licenses-fonts',
+            'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap',
+            [],
+            null
+        );
+
+        wp_enqueue_style( 'lotus-licenses-style', get_stylesheet_uri(), [], LOTUS_LICENSES_VERSION );
+        wp_enqueue_style( 'lotus-licenses-theme', LOTUS_LICENSES_URI . 'assets/css/theme.css', [ 'lotus-licenses-style' ], LOTUS_LICENSES_VERSION );
+
+        wp_enqueue_script( 'lotus-licenses-theme', LOTUS_LICENSES_URI . 'assets/js/theme.js', [ 'jquery' ], LOTUS_LICENSES_VERSION, true );
+
+        wp_localize_script(
+            'lotus-licenses-theme',
+            'lotusLicensesSettings',
+            [
+                'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+            ]
+        );
+    }
+}
+add_action( 'wp_enqueue_scripts', 'lotus_licenses_scripts' );
+
+if ( ! function_exists( 'lotus_licenses_admin_styles' ) ) {
+    /**
+     * Load styles for editor and widgets.
+     */
+    function lotus_licenses_admin_styles() {
+        wp_enqueue_style( 'lotus-licenses-admin', LOTUS_LICENSES_URI . 'assets/css/theme.css', [], LOTUS_LICENSES_VERSION );
+    }
+}
+add_action( 'enqueue_block_editor_assets', 'lotus_licenses_admin_styles' );

--- a/wordpress-theme/lotus-licenses/inc/setup.php
+++ b/wordpress-theme/lotus-licenses/inc/setup.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Theme setup.
+ *
+ * @package Lotus_Licenses
+ */
+
+if ( ! function_exists( 'lotus_licenses_setup' ) ) {
+    /**
+     * Register theme supports and global settings.
+     */
+    function lotus_licenses_setup() {
+        load_theme_textdomain( 'lotus-licenses', LOTUS_LICENSES_PATH . 'languages' );
+
+        add_theme_support( 'automatic-feed-links' );
+        add_theme_support( 'title-tag' );
+        add_theme_support( 'post-thumbnails' );
+        add_theme_support( 'woocommerce' );
+        add_theme_support( 'align-wide' );
+        add_theme_support( 'responsive-embeds' );
+        add_theme_support( 'editor-styles' );
+        add_editor_style( 'assets/css/theme.css' );
+
+        register_nav_menus(
+            [
+                'primary'   => __( 'Primary Menu', 'lotus-licenses' ),
+                'secondary' => __( 'Secondary Menu', 'lotus-licenses' ),
+                'footer'    => __( 'Footer Menu', 'lotus-licenses' ),
+            ]
+        );
+
+        add_theme_support(
+            'custom-logo',
+            [
+                'height'      => 64,
+                'width'       => 240,
+                'flex-height' => true,
+                'flex-width'  => true,
+            ]
+        );
+    }
+}
+add_action( 'after_setup_theme', 'lotus_licenses_setup' );
+
+if ( ! function_exists( 'lotus_licenses_widgets_init' ) ) {
+    /**
+     * Register widget areas.
+     */
+    function lotus_licenses_widgets_init() {
+        register_sidebar(
+            [
+                'name'          => __( 'Footer Column 1', 'lotus-licenses' ),
+                'id'            => 'footer-1',
+                'description'   => __( 'Displayed in the first column of the footer.', 'lotus-licenses' ),
+                'before_widget' => '<div id="%1$s" class="widget %2$s">',
+                'after_widget'  => '</div>',
+                'before_title'  => '<h3 class="widget-title">',
+                'after_title'   => '</h3>',
+            ]
+        );
+
+        register_sidebar(
+            [
+                'name'          => __( 'Footer Column 2', 'lotus-licenses' ),
+                'id'            => 'footer-2',
+                'description'   => __( 'Displayed in the second column of the footer.', 'lotus-licenses' ),
+                'before_widget' => '<div id="%1$s" class="widget %2$s">',
+                'after_widget'  => '</div>',
+                'before_title'  => '<h3 class="widget-title">',
+                'after_title'   => '</h3>',
+            ]
+        );
+
+        register_sidebar(
+            [
+                'name'          => __( 'Footer Column 3', 'lotus-licenses' ),
+                'id'            => 'footer-3',
+                'description'   => __( 'Displayed in the third column of the footer.', 'lotus-licenses' ),
+                'before_widget' => '<div id="%1$s" class="widget %2$s">',
+                'after_widget'  => '</div>',
+                'before_title'  => '<h3 class="widget-title">',
+                'after_title'   => '</h3>',
+            ]
+        );
+    }
+}
+add_action( 'widgets_init', 'lotus_licenses_widgets_init' );

--- a/wordpress-theme/lotus-licenses/inc/template-tags.php
+++ b/wordpress-theme/lotus-licenses/inc/template-tags.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Helper template tags.
+ *
+ * @package Lotus_Licenses
+ */
+
+if ( ! function_exists( 'lotus_licenses_get_highlights' ) ) {
+    /**
+     * Return hero highlights array.
+     *
+     * @return array
+     */
+    function lotus_licenses_get_highlights() {
+        $highlights = get_theme_mod( 'lotus_licenses_highlight_metrics', '' );
+
+        if ( empty( $highlights ) ) {
+            return [];
+        }
+
+        $parts = array_map( 'trim', explode( '•', $highlights ) );
+
+        return array_filter( $parts );
+    }
+}
+
+if ( ! function_exists( 'lotus_licenses_get_featured_products' ) ) {
+    /**
+     * Fetch the featured WooCommerce products.
+     *
+     * @param int $per_page Number of products.
+     *
+     * @return WC_Product[]
+     */
+    function lotus_licenses_get_featured_products( $per_page = 6 ) {
+        if ( ! class_exists( 'WC_Product_Query' ) ) {
+            return [];
+        }
+
+        $query = new WC_Product_Query(
+            [
+                'limit'     => $per_page,
+                'status'    => 'publish',
+                'featured'  => true,
+                'orderby'   => 'menu_order',
+                'order'     => 'ASC',
+                'return'    => 'objects',
+            ]
+        );
+
+        return $query->get_products();
+    }
+}
+
+if ( ! function_exists( 'lotus_licenses_render_product_card' ) ) {
+    /**
+     * Output a WooCommerce product card for the front page.
+     *
+     * @param WC_Product $product Product instance.
+     */
+    function lotus_licenses_render_product_card( $product ) {
+        if ( ! class_exists( 'WC_Product' ) ) {
+            return;
+        }
+
+        if ( ! $product instanceof WC_Product ) {
+            return;
+        }
+
+        $permalink = get_permalink( $product->get_id() );
+        ?>
+        <article class="lotus-product-card">
+            <a class="lotus-product-card__link" href="<?php echo esc_url( $permalink ); ?>">
+                <div class="lotus-product-card__badge"><?php esc_html_e( 'Instant Delivery', 'lotus-licenses' ); ?></div>
+                <h3 class="lotus-product-card__title"><?php echo esc_html( $product->get_name() ); ?></h3>
+                <p class="lotus-product-card__excerpt"><?php echo wp_kses_post( wp_trim_words( $product->get_short_description(), 18 ) ); ?></p>
+                <div class="lotus-product-card__meta">
+                    <span class="lotus-product-card__price"><?php echo wp_kses_post( $product->get_price_html() ); ?></span>
+                    <span class="lotus-product-card__cta"><?php esc_html_e( 'View details', 'lotus-licenses' ); ?> →</span>
+                </div>
+            </a>
+        </article>
+        <?php
+    }
+}
+
+if ( ! function_exists( 'lotus_licenses_menu_fallback' ) ) {
+    /**
+     * Fallback for primary menu.
+     */
+    function lotus_licenses_menu_fallback() {
+        echo '<ul class="primary-menu">';
+        wp_list_pages( [ 'title_li' => '' ] );
+        echo '</ul>';
+    }
+}

--- a/wordpress-theme/lotus-licenses/inc/tgmpa.php
+++ b/wordpress-theme/lotus-licenses/inc/tgmpa.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Lightweight plugin bootstrapper executed on theme activation.
+ *
+ * @package Lotus_Licenses
+ */
+
+if ( ! function_exists( 'lotus_licenses_install_plugins' ) ) {
+    /**
+     * Install and activate the required plugins when the theme is enabled.
+     */
+    function lotus_licenses_install_plugins() {
+        if ( ! current_user_can( 'install_plugins' ) ) {
+            return;
+        }
+
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+        require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+
+        $plugins = [
+            [
+                'name'        => __( 'WooCommerce', 'lotus-licenses' ),
+                'slug'        => 'woocommerce',
+                'file'        => 'woocommerce/woocommerce.php',
+                'is_required' => true,
+            ],
+            [
+                'name'        => __( 'Elementor Website Builder', 'lotus-licenses' ),
+                'slug'        => 'elementor',
+                'file'        => 'elementor/elementor.php',
+                'is_required' => false,
+            ],
+            [
+                'name'        => __( 'Contact Form 7', 'lotus-licenses' ),
+                'slug'        => 'contact-form-7',
+                'file'        => 'contact-form-7/wp-contact-form-7.php',
+                'is_required' => false,
+            ],
+            [
+                'name'        => __( 'Yoast SEO', 'lotus-licenses' ),
+                'slug'        => 'wordpress-seo',
+                'file'        => 'wordpress-seo/wp-seo.php',
+                'is_required' => false,
+            ],
+        ];
+
+        $notices = [];
+
+        foreach ( $plugins as $plugin ) {
+            $plugin_file = WP_PLUGIN_DIR . '/' . $plugin['file'];
+
+            if ( file_exists( $plugin_file ) ) {
+                $result = activate_plugin( $plugin['file'] );
+                if ( is_wp_error( $result ) ) {
+                    $notices[] = sprintf( __( 'Could not activate %1$s: %2$s', 'lotus-licenses' ), $plugin['name'], $result->get_error_message() );
+                }
+                continue;
+            }
+
+            $api = plugins_api(
+                'plugin_information',
+                [
+                    'slug'   => $plugin['slug'],
+                    'fields' => [ 'sections' => false ],
+                ]
+            );
+
+            if ( is_wp_error( $api ) || empty( $api->download_link ) ) {
+                $notices[] = sprintf( __( 'Unable to retrieve the download link for %s.', 'lotus-licenses' ), $plugin['name'] );
+                continue;
+            }
+
+            $skin     = new Automatic_Upgrader_Skin();
+            $upgrader = new Plugin_Upgrader( $skin );
+            $result   = $upgrader->install( $api->download_link );
+
+            if ( is_wp_error( $result ) ) {
+                $notices[] = sprintf( __( 'Installation failed for %1$s: %2$s', 'lotus-licenses' ), $plugin['name'], $result->get_error_message() );
+                continue;
+            }
+
+            $activate = activate_plugin( $plugin['file'] );
+            if ( is_wp_error( $activate ) ) {
+                $notices[] = sprintf( __( 'Installed but could not activate %1$s: %2$s', 'lotus-licenses' ), $plugin['name'], $activate->get_error_message() );
+            }
+        }
+
+        if ( ! empty( $notices ) ) {
+            set_transient( 'lotus_licenses_plugin_notices', $notices, MINUTE_IN_SECONDS * 30 );
+        }
+    }
+}
+add_action( 'after_switch_theme', 'lotus_licenses_install_plugins' );
+
+if ( ! function_exists( 'lotus_licenses_plugin_admin_notices' ) ) {
+    /**
+     * Display any installation or activation notices.
+     */
+    function lotus_licenses_plugin_admin_notices() {
+        $notices = get_transient( 'lotus_licenses_plugin_notices' );
+
+        if ( empty( $notices ) ) {
+            return;
+        }
+
+        delete_transient( 'lotus_licenses_plugin_notices' );
+        ?>
+        <div class="notice notice-warning is-dismissible">
+            <p><strong><?php esc_html_e( 'Lotus Licenses Theme Notice', 'lotus-licenses' ); ?></strong></p>
+            <ul>
+                <?php foreach ( $notices as $notice ) : ?>
+                    <li><?php echo wp_kses_post( $notice ); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+        <?php
+    }
+}
+add_action( 'admin_notices', 'lotus_licenses_plugin_admin_notices' );

--- a/wordpress-theme/lotus-licenses/index.php
+++ b/wordpress-theme/lotus-licenses/index.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Main template file.
+ *
+ * @package Lotus_Licenses
+ */
+
+get_header();
+?>
+<div class="site-container content-area">
+    <?php if ( have_posts() ) : ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <article id="post-<?php the_ID(); ?>" <?php post_class( 'entry' ); ?>>
+                <?php if ( has_post_thumbnail() ) : ?>
+                    <div class="entry__media">
+                        <a href="<?php the_permalink(); ?>">
+                            <?php the_post_thumbnail( 'large' ); ?>
+                        </a>
+                    </div>
+                <?php endif; ?>
+                <header class="entry__header">
+                    <?php the_title( '<h1 class="entry__title">', '</h1>' ); ?>
+                </header>
+                <div class="entry__content">
+                    <?php the_excerpt(); ?>
+                </div>
+                <footer class="entry__footer">
+                    <a class="button button--primary" href="<?php the_permalink(); ?>"><?php esc_html_e( 'Continue reading', 'lotus-licenses' ); ?></a>
+                </footer>
+            </article>
+        <?php endwhile; ?>
+        <div class="pagination">
+            <?php the_posts_pagination(); ?>
+        </div>
+    <?php else : ?>
+        <p><?php esc_html_e( 'We could not find any content. Start publishing to showcase your catalog and resources.', 'lotus-licenses' ); ?></p>
+    <?php endif; ?>
+</div>
+<?php
+get_footer();

--- a/wordpress-theme/lotus-licenses/page.php
+++ b/wordpress-theme/lotus-licenses/page.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Page template.
+ *
+ * @package Lotus_Licenses
+ */
+
+get_header();
+?>
+<div class="site-container content-area">
+    <?php while ( have_posts() ) : the_post(); ?>
+        <article id="post-<?php the_ID(); ?>" <?php post_class( 'entry entry--page' ); ?>>
+            <header class="entry__header">
+                <?php the_title( '<h1 class="entry__title">', '</h1>' ); ?>
+            </header>
+            <div class="entry__content">
+                <?php the_content(); ?>
+            </div>
+        </article>
+        <?php
+        if ( comments_open() || get_comments_number() ) {
+            comments_template();
+        }
+        ?>
+    <?php endwhile; ?>
+</div>
+<?php
+get_footer();

--- a/wordpress-theme/lotus-licenses/single.php
+++ b/wordpress-theme/lotus-licenses/single.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Single post template.
+ *
+ * @package Lotus_Licenses
+ */
+
+get_header();
+?>
+<div class="site-container content-area">
+    <?php while ( have_posts() ) : the_post(); ?>
+        <article id="post-<?php the_ID(); ?>" <?php post_class( 'entry entry--single' ); ?>>
+            <header class="entry__header">
+                <?php the_title( '<h1 class="entry__title">', '</h1>' ); ?>
+                <div class="entry__meta">
+                    <span><?php echo esc_html( get_the_date() ); ?></span>
+                    <span><?php esc_html_e( 'by', 'lotus-licenses' ); ?> <?php the_author_posts_link(); ?></span>
+                </div>
+            </header>
+            <div class="entry__content">
+                <?php the_content(); ?>
+            </div>
+            <footer class="entry__footer">
+                <?php the_tags( '<div class="entry__tags">' . esc_html__( 'Tags: ', 'lotus-licenses' ), ', ', '</div>' ); ?>
+            </footer>
+        </article>
+        <?php
+        if ( comments_open() || get_comments_number() ) {
+            comments_template();
+        }
+        ?>
+        <nav class="post-navigation">
+            <?php the_post_navigation(); ?>
+        </nav>
+    <?php endwhile; ?>
+</div>
+<?php
+get_footer();

--- a/wordpress-theme/lotus-licenses/style.css
+++ b/wordpress-theme/lotus-licenses/style.css
@@ -1,0 +1,259 @@
+/*
+Theme Name: Lotus Licenses
+Theme URI: https://example.com/themes/lotus-licenses
+Author: Reseller Script
+Author URI: https://example.com/
+Description: A polished, conversion-driven WooCommerce theme crafted for software license stores and digital resellers. Packed with SEO-friendly markup, immersive layouts, and seamless WooCommerce integration to deliver a premium purchasing experience that mirrors the Lotus Lisans aesthetic.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: lotus-licenses
+Tags: e-commerce, woocommerce, responsive, custom-background, custom-logo, custom-menu
+*/
+
+/*
+====================================================================
+  Base styles for the Lotus Licenses theme. Additional presentation
+  lives in assets/css/theme.css and is enqueued automatically.
+====================================================================
+*/
+
+:root {
+    --lotus-primary: #3f37c9;
+    --lotus-primary-dark: #3125a0;
+    --lotus-secondary: #4cc9f0;
+    --lotus-secondary-dark: #4361ee;
+    --lotus-success: #80ffdb;
+    --lotus-warning: #ffb703;
+    --lotus-danger: #f72585;
+    --lotus-dark: #1b1b33;
+    --lotus-text: #2c2c4c;
+    --lotus-muted: #6c7196;
+    --lotus-background: #f5f6ff;
+    --lotus-radius-lg: 32px;
+    --lotus-radius-md: 20px;
+    --lotus-radius-sm: 12px;
+    --lotus-shadow-lg: 0 40px 70px rgba(27, 27, 51, 0.18);
+    --lotus-shadow-md: 0 24px 40px rgba(34, 39, 63, 0.12);
+    --lotus-shadow-sm: 0 12px 24px rgba(34, 39, 63, 0.08);
+    --lotus-transition: 250ms cubic-bezier(0.4, 0, 0.2, 1);
+    --lotus-font: "Plus Jakarta Sans", "Inter", "Segoe UI", sans-serif;
+}
+
+html {
+    box-sizing: border-box;
+    scroll-behavior: smooth;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: inherit;
+}
+
+body {
+    margin: 0;
+    font-family: var(--lotus-font);
+    color: var(--lotus-text);
+    background: var(--lotus-background);
+    font-size: 16px;
+    line-height: 1.6;
+}
+
+a {
+    color: var(--lotus-primary);
+    text-decoration: none;
+    transition: color var(--lotus-transition);
+}
+
+a:hover,
+a:focus {
+    color: var(--lotus-secondary-dark);
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+}
+
+.screen-reader-text {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    word-wrap: normal !important;
+}
+
+.alignfull {
+    width: 100vw;
+    position: relative;
+    left: 50%;
+    right: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+}
+
+.alignwide {
+    max-width: min(1200px, 90vw);
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.wp-caption {
+    max-width: 100%;
+}
+
+.wp-caption-text {
+    color: var(--lotus-muted);
+    font-size: 0.95rem;
+}
+
+.entry-content > * + * {
+    margin-top: 1.75rem;
+}
+
+.entry-content ul,
+.entry-content ol {
+    padding-left: 1.75rem;
+}
+
+.entry-content blockquote {
+    padding: 1.5rem 2rem;
+    border-left: 4px solid var(--lotus-secondary);
+    background: rgba(76, 201, 240, 0.12);
+    border-radius: var(--lotus-radius-sm);
+}
+
+.site-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2rem;
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 999;
+    backdrop-filter: blur(14px);
+    background: rgba(245, 246, 255, 0.85);
+    border-bottom: 1px solid rgba(63, 55, 201, 0.08);
+    transition: transform var(--lotus-transition);
+}
+
+.site-header__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem 0;
+}
+
+.primary-menu {
+    display: flex;
+    gap: 1.5rem;
+    align-items: center;
+}
+
+.primary-menu a {
+    font-weight: 600;
+    color: var(--lotus-text);
+    font-size: 0.95rem;
+}
+
+.primary-menu a:hover,
+.primary-menu a:focus,
+.primary-menu .current-menu-item > a,
+.primary-menu .current-menu-ancestor > a {
+    color: var(--lotus-primary);
+}
+
+.site-footer {
+    background: var(--lotus-dark);
+    color: rgba(255, 255, 255, 0.85);
+    padding: 4rem 0 2.5rem;
+}
+
+.site-footer__grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.site-footer__logo {
+    font-weight: 700;
+    font-size: 1.35rem;
+}
+
+.site-footer__menu ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.site-footer__cta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.site-footer__cta a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.65rem;
+    border-radius: 999px;
+    background: linear-gradient(120deg, var(--lotus-secondary), var(--lotus-primary));
+    color: #fff;
+    padding: 0.85rem 1.6rem;
+    font-weight: 600;
+}
+
+.site-footer__bottom {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 992px) {
+    .site-header__inner {
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .primary-menu {
+        width: 100%;
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    .site-container {
+        padding: 0 1.5rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .site-container {
+        padding: 0 1.25rem;
+    }
+
+    body {
+        font-size: 15px;
+    }
+}
+
+.site-header--hidden {
+    transform: translateY(-100%);
+    transition: transform var(--lotus-transition);
+}

--- a/wordpress-theme/lotus-licenses/template-parts/cta.php
+++ b/wordpress-theme/lotus-licenses/template-parts/cta.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Final call to action.
+ *
+ * @package Lotus_Licenses
+ */
+?>
+<section class="lotus-section lotus-section--cta">
+    <div class="site-container lotus-cta">
+        <div class="lotus-cta__content">
+            <h2><?php esc_html_e( 'Launch your license empire today', 'lotus-licenses' ); ?></h2>
+            <p><?php esc_html_e( 'Install the Lotus Licenses theme, sync WooCommerce, and unlock a blazing-fast storefront that mirrors the Lotus Lisans experience.', 'lotus-licenses' ); ?></p>
+        </div>
+        <div class="lotus-cta__actions">
+            <?php $shop_link = function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'shop' ) : home_url( '/shop' ); ?>
+            <a class="button button--primary" href="<?php echo esc_url( $shop_link ); ?>"><?php esc_html_e( 'Browse catalog', 'lotus-licenses' ); ?></a>
+            <a class="button button--ghost" href="<?php echo esc_url( admin_url( 'customize.php' ) ); ?>"><?php esc_html_e( 'Customize theme', 'lotus-licenses' ); ?></a>
+        </div>
+    </div>
+</section>

--- a/wordpress-theme/lotus-licenses/template-parts/features.php
+++ b/wordpress-theme/lotus-licenses/template-parts/features.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Features grid.
+ *
+ * @package Lotus_Licenses
+ */
+?>
+<section class="lotus-section lotus-section--features">
+    <div class="site-container">
+        <div class="lotus-section__heading">
+            <span class="lotus-section__eyebrow"><?php esc_html_e( 'Why choose Lotus Licenses?', 'lotus-licenses' ); ?></span>
+            <h2><?php esc_html_e( 'All-in-one toolkit for software resellers', 'lotus-licenses' ); ?></h2>
+            <p><?php esc_html_e( 'Effortlessly manage digital SKUs, deliver activation keys, and build profitable subscription funnels with conversion-optimized UX.', 'lotus-licenses' ); ?></p>
+        </div>
+        <div class="lotus-feature-grid">
+            <article class="lotus-feature-card">
+                <div class="lotus-feature-card__icon" aria-hidden="true">⚡</div>
+                <h3><?php esc_html_e( 'Instant key delivery', 'lotus-licenses' ); ?></h3>
+                <p><?php esc_html_e( 'Connect to supplier APIs, auto-generate license emails, and ship keys in seconds after purchase.', 'lotus-licenses' ); ?></p>
+            </article>
+            <article class="lotus-feature-card">
+                <div class="lotus-feature-card__icon" aria-hidden="true">🛡️</div>
+                <h3><?php esc_html_e( 'Fraud prevention stack', 'lotus-licenses' ); ?></h3>
+                <p><?php esc_html_e( 'Dynamic risk scoring, velocity rules, and 3D secure prompts keep your margin safe from abuse.', 'lotus-licenses' ); ?></p>
+            </article>
+            <article class="lotus-feature-card">
+                <div class="lotus-feature-card__icon" aria-hidden="true">📊</div>
+                <h3><?php esc_html_e( 'Executive analytics', 'lotus-licenses' ); ?></h3>
+                <p><?php esc_html_e( 'Surface cohort retention, attach rates, and supplier ROI from a unified sales intelligence suite.', 'lotus-licenses' ); ?></p>
+            </article>
+            <article class="lotus-feature-card">
+                <div class="lotus-feature-card__icon" aria-hidden="true">🤝</div>
+                <h3><?php esc_html_e( 'Partner-ready experiences', 'lotus-licenses' ); ?></h3>
+                <p><?php esc_html_e( 'Spin up co-branded landing pages, tier-based pricing, and account-based offers to scale wholesale relationships.', 'lotus-licenses' ); ?></p>
+            </article>
+        </div>
+    </div>
+</section>

--- a/wordpress-theme/lotus-licenses/template-parts/hero.php
+++ b/wordpress-theme/lotus-licenses/template-parts/hero.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Hero section.
+ *
+ * @package Lotus_Licenses
+ */
+
+$headline     = get_theme_mod( 'lotus_licenses_hero_headline', __( 'Enterprise-Grade License Automation', 'lotus-licenses' ) );
+$subheadline  = get_theme_mod( 'lotus_licenses_hero_subheadline', __( 'Launch a dazzling storefront that syncs your digital licenses in real time and converts visitors into lifelong customers.', 'lotus-licenses' ) );
+$default_url  = function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'shop' ) : home_url( '/shop' );
+$primary_url  = get_theme_mod( 'lotus_licenses_hero_primary_url', $default_url );
+$primary_text = get_theme_mod( 'lotus_licenses_hero_primary_label', __( 'Explore Products', 'lotus-licenses' ) );
+$highlights   = lotus_licenses_get_highlights();
+?>
+<section class="lotus-hero">
+    <div class="site-container lotus-hero__inner">
+        <div class="lotus-hero__content">
+            <div class="lotus-hero__eyebrow"><?php esc_html_e( 'Premium WooCommerce Theme', 'lotus-licenses' ); ?></div>
+            <h1 class="lotus-hero__headline"><?php echo esc_html( $headline ); ?></h1>
+            <p class="lotus-hero__subheadline"><?php echo esc_html( $subheadline ); ?></p>
+            <div class="lotus-hero__actions">
+                <a class="button button--primary" href="<?php echo esc_url( $primary_url ); ?>"><?php echo esc_html( $primary_text ); ?></a>
+                <a class="button button--ghost" href="<?php echo esc_url( site_url( '/contact' ) ); ?>"><?php esc_html_e( 'Request a demo', 'lotus-licenses' ); ?></a>
+            </div>
+            <?php if ( $highlights ) : ?>
+                <ul class="lotus-hero__metrics">
+                    <?php foreach ( $highlights as $highlight ) : ?>
+                        <li><?php echo esc_html( $highlight ); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </div>
+        <div class="lotus-hero__media" aria-hidden="true">
+            <div class="lotus-hero__card">
+                <span class="lotus-hero__badge"><?php esc_html_e( 'Auto Fulfilment', 'lotus-licenses' ); ?></span>
+                <h3><?php esc_html_e( 'Digital License Hub', 'lotus-licenses' ); ?></h3>
+                <p><?php esc_html_e( 'Synchronize keys from your distributors, validate orders, and dispatch delivery emails within seconds.', 'lotus-licenses' ); ?></p>
+                <ul>
+                    <li><?php esc_html_e( 'AI-powered fraud shield', 'lotus-licenses' ); ?></li>
+                    <li><?php esc_html_e( 'Instant license provisioning', 'lotus-licenses' ); ?></li>
+                    <li><?php esc_html_e( 'White-labeled communications', 'lotus-licenses' ); ?></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</section>

--- a/wordpress-theme/lotus-licenses/template-parts/product-showcase.php
+++ b/wordpress-theme/lotus-licenses/template-parts/product-showcase.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Featured product showcase.
+ *
+ * @package Lotus_Licenses
+ */
+
+$products = lotus_licenses_get_featured_products();
+?>
+<section class="lotus-section lotus-section--products">
+    <div class="site-container">
+        <div class="lotus-section__heading">
+            <span class="lotus-section__eyebrow"><?php esc_html_e( 'High-converting catalog templates', 'lotus-licenses' ); ?></span>
+            <h2><?php esc_html_e( 'Showcase your best-selling licenses', 'lotus-licenses' ); ?></h2>
+            <p><?php esc_html_e( 'Lotus Licenses ships with bespoke WooCommerce layouts that spotlight value, reduce friction, and maximize average order value.', 'lotus-licenses' ); ?></p>
+        </div>
+        <?php if ( $products ) : ?>
+            <div class="lotus-product-grid">
+                <?php foreach ( $products as $product ) : ?>
+                    <?php lotus_licenses_render_product_card( $product ); ?>
+                <?php endforeach; ?>
+            </div>
+        <?php else : ?>
+            <div class="lotus-product-placeholder">
+                <h3><?php esc_html_e( 'Activate WooCommerce featured products', 'lotus-licenses' ); ?></h3>
+                <p><?php esc_html_e( 'Mark products as “Featured” to populate this curated grid automatically once WooCommerce is configured.', 'lotus-licenses' ); ?></p>
+                <a class="button button--primary" href="<?php echo esc_url( admin_url( 'edit.php?post_type=product' ) ); ?>"><?php esc_html_e( 'Manage products', 'lotus-licenses' ); ?></a>
+            </div>
+        <?php endif; ?>
+    </div>
+</section>

--- a/wordpress-theme/lotus-licenses/template-parts/testimonials.php
+++ b/wordpress-theme/lotus-licenses/template-parts/testimonials.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Testimonials section.
+ *
+ * @package Lotus_Licenses
+ */
+?>
+<section class="lotus-section lotus-section--testimonials">
+    <div class="site-container">
+        <div class="lotus-section__heading">
+            <span class="lotus-section__eyebrow"><?php esc_html_e( 'Trusted by global resellers', 'lotus-licenses' ); ?></span>
+            <h2><?php esc_html_e( 'What growth leaders say', 'lotus-licenses' ); ?></h2>
+        </div>
+        <div class="lotus-testimonial-carousel" data-behavior="testimonial-slider">
+            <article class="lotus-testimonial">
+                <blockquote>
+                    <p><?php esc_html_e( 'Within two weeks we migrated our entire software catalog and reduced manual license fulfilment by 93%. Lotus Licenses is the growth lever we needed.', 'lotus-licenses' ); ?></p>
+                </blockquote>
+                <div class="lotus-testimonial__meta">
+                    <span class="lotus-testimonial__name"><?php esc_html_e( 'Elena Hart', 'lotus-licenses' ); ?></span>
+                    <span class="lotus-testimonial__role"><?php esc_html_e( 'Head of Ecommerce, PixelWave Labs', 'lotus-licenses' ); ?></span>
+                </div>
+            </article>
+            <article class="lotus-testimonial">
+                <blockquote>
+                    <p><?php esc_html_e( 'Our B2B licensing program now runs on autopilot. Subscription renewals, VAT invoicing, and partner dashboards just work.', 'lotus-licenses' ); ?></p>
+                </blockquote>
+                <div class="lotus-testimonial__meta">
+                    <span class="lotus-testimonial__name"><?php esc_html_e( 'Rahul Iqbal', 'lotus-licenses' ); ?></span>
+                    <span class="lotus-testimonial__role"><?php esc_html_e( 'COO, CloudFrame Distribution', 'lotus-licenses' ); ?></span>
+                </div>
+            </article>
+            <article class="lotus-testimonial">
+                <blockquote>
+                    <p><?php esc_html_e( 'The conversion uplift was immediate. Prebuilt landing sections and intelligent merchandising increased average order value by 41%.', 'lotus-licenses' ); ?></p>
+                </blockquote>
+                <div class="lotus-testimonial__meta">
+                    <span class="lotus-testimonial__name"><?php esc_html_e( 'Grace Nguyen', 'lotus-licenses' ); ?></span>
+                    <span class="lotus-testimonial__role"><?php esc_html_e( 'VP Marketing, NovaKeys', 'lotus-licenses' ); ?></span>
+                </div>
+            </article>
+        </div>
+    </div>
+</section>

--- a/wordpress-theme/lotus-licenses/woocommerce.php
+++ b/wordpress-theme/lotus-licenses/woocommerce.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * WooCommerce wrapper.
+ *
+ * @package Lotus_Licenses
+ */
+
+get_header();
+?>
+<div class="site-container content-area">
+    <?php woocommerce_content(); ?>
+</div>
+<?php
+get_footer();


### PR DESCRIPTION
## Summary
- introduce the Lotus Licenses WordPress theme with modular hero, feature, product, testimonial, and CTA sections inspired by Lotus Lisans
- wire up WooCommerce-ready theme setup, Customizer controls, and asset pipeline for typography, styling, and interactive enhancements
- add an activation hook that installs or activates WooCommerce, Elementor, Contact Form 7, and Yoast SEO automatically, plus document theme usage

## Testing
- find wordpress-theme/lotus-licenses -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_b_68da6714b6848325a62bfa87773a5e2a