### PR TITLE
Add Chrome extension to export Lotus product catalog to CSV

### DIFF
--- a/chrome-extension/lotus-scraper/README.md
+++ b/chrome-extension/lotus-scraper/README.md
@@ -1,0 +1,21 @@
+# Lotus Ürün Aktarıcı Chrome Eklentisi
+
+Lotus Partner Panelindeki tüm kategori ve alt kategori sayfalarını dolaşarak ürün isimlerini ve kredi fiyatlarını CSV olarak indiren bir Chrome eklentisi.
+
+## Özellikler
+
+- Kategori ve alt kategorilerdeki tüm "Ürünler" bağlantılarını otomatik olarak keşfeder.
+- Kart veya tablo düzenindeki ürünleri algılar.
+- Toplanan verileri kategori yolu, ürün adı, fiyat ve kaynak URL bilgileriyle CSV olarak indirir.
+- Tarama ilerlemesini eklenti penceresinden takip etmeyi sağlar.
+
+## Kurulum
+
+1. Klasörü indirin veya depoyu klonlayın.
+2. Chrome'da `chrome://extensions` adresine gidin.
+3. Geliştirici modunu etkinleştirin.
+4. "Paketlenmemiş uzantı yükle" seçeneği ile `chrome-extension/lotus-scraper` klasörünü seçin.
+5. Lotus Partner Paneline giriş yapıp kategori sayfasını açın.
+6. Eklenti simgesine tıklayıp "Taramayı Başlat" butonuna basın.
+
+Tarama tamamlandığında CSV dosyası otomatik olarak indirilecektir.

--- a/chrome-extension/lotus-scraper/content-script.js
+++ b/chrome-extension/lotus-scraper/content-script.js
@@ -1,0 +1,260 @@
+(() => {
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const normalizeUrl = (rawUrl) => {
+    try {
+      const url = new URL(rawUrl, window.location.origin);
+      if (url.origin !== window.location.origin) {
+        return null;
+      }
+      if (!url.pathname.startsWith('/kategori')) {
+        return null;
+      }
+      url.hash = '';
+      return url.toString();
+    } catch (error) {
+      return null;
+    }
+  };
+
+  const collectCategoryLinks = (doc) => {
+    const links = new Set();
+    const anchors = doc.querySelectorAll('a[href]');
+    anchors.forEach((anchor) => {
+      const href = anchor.getAttribute('href');
+      if (!href || href.startsWith('javascript:')) {
+        return;
+      }
+      const normalized = normalizeUrl(href);
+      if (normalized) {
+        links.add(normalized);
+      }
+    });
+    return Array.from(links);
+  };
+
+  const extractCategoryPath = (url) => {
+    try {
+      const urlObj = new URL(url);
+      const segments = urlObj.pathname.split('/').filter(Boolean);
+      if (segments[0] !== 'kategori') {
+        return '';
+      }
+      const filtered = segments
+        .slice(1)
+        .filter((segment) => !/^\d+$/.test(segment))
+        .map((segment) => decodeURIComponent(segment.replace(/-/g, ' ')));
+      return filtered.join(' > ');
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const findPriceElement = (root) => {
+    const stack = [root];
+    while (stack.length) {
+      const node = stack.shift();
+      if (node.textContent && /kredi/i.test(node.textContent)) {
+        return node;
+      }
+      stack.push(...node.children);
+    }
+    return null;
+  };
+
+  const extractProductsFromCards = (doc, sourceUrl) => {
+    const products = [];
+    const cardBodies = doc.querySelectorAll('.card .card-body');
+    cardBodies.forEach((body) => {
+      const priceEl = findPriceElement(body);
+      if (!priceEl) {
+        return;
+      }
+      const titleEl = body.querySelector('.card-title, h5, h4, h3, .product-title');
+      if (!titleEl) {
+        return;
+      }
+      const name = titleEl.textContent.trim();
+      const price = priceEl.textContent.replace(/\s+/g, ' ').trim();
+      if (!name || !price) {
+        return;
+      }
+      products.push({
+        name,
+        price,
+        sourceUrl,
+      });
+    });
+    return products;
+  };
+
+  const extractProductsFromTables = (doc, sourceUrl) => {
+    const products = [];
+    const rows = doc.querySelectorAll('table tbody tr');
+    rows.forEach((row) => {
+      const cells = Array.from(row.querySelectorAll('td, th'));
+      if (cells.length === 0) {
+        return;
+      }
+      const priceCellIndex = cells.findIndex((cell) => /kredi/i.test(cell.textContent));
+      if (priceCellIndex === -1) {
+        return;
+      }
+      const price = cells[priceCellIndex].textContent.replace(/\s+/g, ' ').trim();
+      const nameCell = cells.find((cell, index) => index !== priceCellIndex && cell.textContent.trim().length > 0);
+      if (!nameCell) {
+        return;
+      }
+      const name = nameCell.textContent.replace(/\s+/g, ' ').trim();
+      if (!name || !price) {
+        return;
+      }
+      products.push({
+        name,
+        price,
+        sourceUrl,
+      });
+    });
+    return products;
+  };
+
+  const mergeProducts = (existing, incoming, categoryPath) => {
+    incoming.forEach((product) => {
+      const key = `${product.name}__${product.price}__${categoryPath}`;
+      if (!existing.has(key)) {
+        existing.set(key, {
+          categoryPath,
+          name: product.name,
+          price: product.price,
+          sourceUrl: product.sourceUrl,
+        });
+      }
+    });
+  };
+
+  const convertToCsv = (records) => {
+    const headers = ['Kategori Yolu', 'Ürün Adı', 'Fiyat', 'Kaynak URL'];
+    const lines = [headers.join(',')];
+    records.forEach((record) => {
+      const values = [record.categoryPath, record.name, record.price, record.sourceUrl].map((value) => {
+        const safe = value.replace(/"/g, '""');
+        return `"${safe}"`;
+      });
+      lines.push(values.join(','));
+    });
+    return lines.join('\n');
+  };
+
+  const triggerDownload = (filename, content) => {
+    const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.style.display = 'none';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const notifyProgress = (payload) => {
+    chrome.runtime.sendMessage({ action: 'scrapeProgress', ...payload });
+  };
+
+  const scrapeAllProducts = async () => {
+    const startUrl = normalizeUrl(window.location.href);
+    if (!startUrl) {
+      throw new Error('Mevcut sayfa lotus kategori sayfası değil. Lütfen kategori sayfasını açın.');
+    }
+
+    const queue = [];
+    const visited = new Set();
+    if (startUrl) {
+      queue.push(startUrl);
+    }
+
+    const initialLinks = collectCategoryLinks(document);
+    initialLinks.forEach((link) => {
+      if (!queue.includes(link)) {
+        queue.push(link);
+      }
+    });
+
+    const productsMap = new Map();
+    let processedCount = 0;
+
+    while (queue.length > 0) {
+      const currentUrl = queue.shift();
+      if (visited.has(currentUrl)) {
+        continue;
+      }
+      visited.add(currentUrl);
+
+      notifyProgress({ type: 'status', message: `Sayfa inceleniyor: ${currentUrl}` });
+
+      let response;
+      try {
+        response = await fetch(currentUrl, { credentials: 'include' });
+      } catch (error) {
+        notifyProgress({ type: 'error', message: `${currentUrl} adresi alınamadı: ${error.message}` });
+        continue;
+      }
+
+      if (!response.ok) {
+        notifyProgress({ type: 'error', message: `${currentUrl} için beklenmeyen yanıt: ${response.status}` });
+        continue;
+      }
+
+      const html = await response.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+
+      const categoryPath = extractCategoryPath(currentUrl);
+
+      const cardProducts = extractProductsFromCards(doc, currentUrl);
+      const tableProducts = extractProductsFromTables(doc, currentUrl);
+      mergeProducts(productsMap, cardProducts, categoryPath);
+      mergeProducts(productsMap, tableProducts, categoryPath);
+
+      processedCount += 1;
+      notifyProgress({ type: 'status', message: `Toplanan ürün sayısı: ${productsMap.size}` });
+
+      const newLinks = collectCategoryLinks(doc);
+      newLinks.forEach((link) => {
+        if (!visited.has(link) && !queue.includes(link)) {
+          queue.push(link);
+        }
+      });
+
+      await sleep(250);
+    }
+
+    if (productsMap.size === 0) {
+      throw new Error('Herhangi bir ürün bulunamadı. Giriş yapıldığından ve ürün sayfasında olunduğundan emin olun.');
+    }
+
+    const records = Array.from(productsMap.values());
+    const csv = convertToCsv(records);
+    const timestamp = new Date().toISOString().replace(/[:T]/g, '-').split('.')[0];
+    const filename = `lotus-urunler-${timestamp}.csv`;
+    triggerDownload(filename, csv);
+
+    notifyProgress({ type: 'complete', message: `${records.length} ürün başarıyla indirildi.`, filename });
+
+    return { filename, recordCount: records.length, visitedPages: processedCount };
+  };
+
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message?.action === 'scrapeProducts') {
+      scrapeAllProducts()
+        .then((result) => sendResponse({ success: true, result }))
+        .catch((error) => {
+          notifyProgress({ type: 'error', message: error.message });
+          sendResponse({ success: false, error: error.message });
+        });
+      return true;
+    }
+    return undefined;
+  });
+})();

--- a/chrome-extension/lotus-scraper/manifest.json
+++ b/chrome-extension/lotus-scraper/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "Lotus Ürün Aktarıcı",
+  "description": "Lotus Partner panelindeki tüm kategori ve alt kategorilerdeki ürünleri dolaşarak isim ve fiyatlarını CSV olarak indirir.",
+  "version": "1.0.0",
+  "permissions": [
+    "scripting"
+  ],
+  "host_permissions": [
+    "https://partner.lotuslisans.com.tr/*"
+  ],
+  "action": {
+    "default_title": "Lotus Ürün Aktarıcı",
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://partner.lotuslisans.com.tr/*"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/chrome-extension/lotus-scraper/popup.css
+++ b/chrome-extension/lotus-scraper/popup.css
@@ -1,0 +1,79 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  width: 340px;
+  min-height: 260px;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+main {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.description {
+  font-size: 0.85rem;
+  margin: 0;
+  line-height: 1.4;
+  color: #cbd5f5;
+}
+
+button {
+  background: linear-gradient(135deg, #0ea5e9, #2563eb);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.45);
+}
+
+button:disabled {
+  background: #475569;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+#status {
+  min-height: 80px;
+  padding: 12px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  overflow-y: auto;
+  max-height: 140px;
+}
+
+.status-line {
+  margin-bottom: 6px;
+}
+
+.status-line.error {
+  color: #fca5a5;
+}
+
+.status-line.success {
+  color: #86efac;
+}

--- a/chrome-extension/lotus-scraper/popup.html
+++ b/chrome-extension/lotus-scraper/popup.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Lotus Ürün Aktarıcı</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Lotus Ürün Aktarıcı</h1>
+      <p class="description">
+        Açık olan Lotus Partner kategori sekmesindeki tüm kategori ve alt kategoriler taranarak ürünlerin isim ve kredi fiyatları CSV olarak indirilecektir.
+      </p>
+      <button id="start-scan">Taramayı Başlat</button>
+      <div id="status" aria-live="polite"></div>
+    </main>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/chrome-extension/lotus-scraper/popup.js
+++ b/chrome-extension/lotus-scraper/popup.js
@@ -1,0 +1,65 @@
+const startButton = document.getElementById('start-scan');
+const statusContainer = document.getElementById('status');
+
+const appendStatus = (message, type = 'info') => {
+  const line = document.createElement('div');
+  line.className = `status-line ${type}`;
+  line.textContent = message;
+  statusContainer.appendChild(line);
+  statusContainer.scrollTop = statusContainer.scrollHeight;
+};
+
+const setLoading = (isLoading) => {
+  startButton.disabled = isLoading;
+  startButton.textContent = isLoading ? 'Taranıyor...' : 'Taramayı Başlat';
+};
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message?.action !== 'scrapeProgress') {
+    return;
+  }
+
+  if (message.type === 'status') {
+    appendStatus(message.message, 'info');
+  } else if (message.type === 'error') {
+    appendStatus(message.message, 'error');
+    setLoading(false);
+  } else if (message.type === 'complete') {
+    appendStatus(message.message, 'success');
+    setLoading(false);
+  }
+});
+
+const triggerScrape = async () => {
+  setLoading(true);
+  statusContainer.textContent = '';
+  appendStatus('Tarama başlatılıyor...');
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab || !tab.id) {
+    appendStatus('Aktif sekme bulunamadı.', 'error');
+    setLoading(false);
+    return;
+  }
+
+  chrome.tabs.sendMessage(tab.id, { action: 'scrapeProducts' }, (response) => {
+    if (!response) {
+      const lastError = chrome.runtime.lastError;
+      appendStatus(lastError ? lastError.message : 'İletişim hatası oluştu.', 'error');
+      setLoading(false);
+      return;
+    }
+
+    if (!response.success) {
+      appendStatus(response.error || 'Bilinmeyen hata oluştu.', 'error');
+      setLoading(false);
+      return;
+    }
+
+    const { result } = response;
+    appendStatus(`Toplam ${result.recordCount} ürün bulundu. Dosya: ${result.filename}`, 'success');
+    setLoading(false);
+  });
+};
+
+startButton.addEventListener('click', triggerScrape);


### PR DESCRIPTION
## Summary
- add a Chrome extension that explores Lotus Partner categories and subcategories and exports product names and credit prices to CSV
- provide a popup interface with progress updates and documentation for installing and running the extension

## Testing
- not run (extension only)


------
https://chatgpt.com/codex/tasks/task_b_68dbea1ee7d08325b7c887d84d946403