### PR TITLE
Add demo mode and read-only demo account

### DIFF
--- a/admin/balances.php
+++ b/admin/balances.php
@@ -6,7 +6,7 @@ use App\Helpers;
 use App\Mailer;
 use App\Telegram;
 
-if (empty($_SESSION['user']) || $_SESSION['user']['role'] !== 'admin') {
+if (empty($_SESSION['user']) || !in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
     Helpers::redirect('/');
 }
 

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -11,7 +11,7 @@ if (empty($_SESSION['user'])) {
 
 $user = $_SESSION['user'];
 
-if ($user['role'] !== 'admin') {
+if (!in_array($user['role'], ['admin', 'demo'], true)) {
     Helpers::redirect('/dashboard.php');
 }
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -5,7 +5,7 @@ use App\Auth;
 use App\Helpers;
 
 if (!empty($_SESSION['user'])) {
-    if ($_SESSION['user']['role'] === 'admin') {
+    if (in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
         Helpers::redirect('/admin/dashboard.php');
     }
 
@@ -23,12 +23,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         $user = Auth::attempt($identifier, $password);
 
-        if ($user && $user['role'] === 'admin') {
+        if ($user && in_array($user['role'], ['admin', 'demo'], true)) {
             $_SESSION['user'] = $user;
             Helpers::redirect('/admin/dashboard.php');
         }
 
-        $errors[] = 'Yalnızca yöneticiler giriş yapabilir. Bilgilerinizi kontrol edin.';
+        $errors[] = 'Yalnızca yetkili kullanıcılar giriş yapabilir. Bilgilerinizi kontrol edin.';
     }
 }
 

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -7,7 +7,7 @@ use App\Auth;
 use App\Mailer;
 use App\Telegram;
 
-if (empty($_SESSION['user']) || $_SESSION['user']['role'] !== 'admin') {
+if (empty($_SESSION['user']) || !in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
     Helpers::redirect('/');
 }
 

--- a/admin/packages.php
+++ b/admin/packages.php
@@ -4,7 +4,7 @@ require __DIR__ . '/../bootstrap.php';
 use App\Helpers;
 use App\Database;
 
-if (empty($_SESSION['user']) || $_SESSION['user']['role'] !== 'admin') {
+if (empty($_SESSION['user']) || !in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
     Helpers::redirect('/');
 }
 

--- a/admin/products.php
+++ b/admin/products.php
@@ -5,7 +5,7 @@ use App\Helpers;
 use App\Database;
 use App\Importers\WooCommerceImporter;
 
-if (empty($_SESSION['user']) || $_SESSION['user']['role'] !== 'admin') {
+if (empty($_SESSION['user']) || !in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
     Helpers::redirect('/');
 }
 

--- a/admin/reports.php
+++ b/admin/reports.php
@@ -5,7 +5,7 @@ use App\Database;
 use App\Helpers;
 use App\Reports\ReportService;
 
-if (empty($_SESSION['user']) || $_SESSION['user']['role'] !== 'admin') {
+if (empty($_SESSION['user']) || !in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
     Helpers::redirect('/');
 }
 

--- a/admin/settings-general.php
+++ b/admin/settings-general.php
@@ -1,0 +1,101 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+use App\Auth;
+use App\Database;
+use App\Helpers;
+use App\Settings;
+
+if (empty($_SESSION['user']) || !in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
+    Helpers::redirect('/');
+}
+
+$pdo = Database::connection();
+$errors = [];
+$success = '';
+$demoModeEnabled = Settings::get('demo_mode_enabled', '0') === '1';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $enableDemo = isset($_POST['demo_mode_enabled']);
+
+    if ($enableDemo) {
+        try {
+            $column = $pdo->query("SHOW COLUMNS FROM users LIKE 'role'")->fetch(\PDO::FETCH_ASSOC);
+            if ($column && strpos($column['Type'], "'demo'") === false) {
+                $pdo->exec("ALTER TABLE users MODIFY role ENUM('admin','reseller','demo') NOT NULL DEFAULT 'reseller'");
+            }
+        } catch (\PDOException $exception) {
+            $errors[] = 'Demo rolü tanımlanırken bir veritabanı hatası oluştu: ' . $exception->getMessage();
+        }
+    }
+
+    if (!$errors) {
+        Settings::set('demo_mode_enabled', $enableDemo ? '1' : '0');
+        $demoModeEnabled = $enableDemo;
+
+        if ($enableDemo) {
+            Auth::ensureDemoAccount(true);
+            $success = 'Demo modu aktifleştirildi. Demo kullanıcı bilgilerini müşterilerinizle paylaşabilirsiniz.';
+        } else {
+            Auth::ensureDemoAccount(false);
+            $success = 'Demo modu devre dışı bırakıldı. Demo kullanıcı giriş yapamaz.';
+        }
+    }
+}
+
+$demoCredentials = [
+    'username' => 'demo',
+    'email' => 'demo@demo.com',
+    'password' => 'demo123!'
+];
+
+$pageTitle = 'Genel Ayarlar';
+
+include __DIR__ . '/../templates/header.php';
+?>
+<div class="row justify-content-center">
+    <div class="col-12 col-lg-8 col-xxl-6">
+        <div class="card border-0 shadow-sm">
+            <div class="card-header bg-white">
+                <h5 class="mb-0">Demo Modu</h5>
+            </div>
+            <div class="card-body">
+                <p class="text-muted">Demo modu, ürününüzü potansiyel müşterilere göstermek için hazır bir yönetici hesabı sunar. Bu hesap yalnızca görüntüleme amaçlıdır ve yapılan değişiklikler kaydedilmez.</p>
+
+                <?php if ($errors): ?>
+                    <div class="alert alert-danger">
+                        <ul class="mb-0">
+                            <?php foreach ($errors as $error): ?>
+                                <li><?= Helpers::sanitize($error) ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                <?php endif; ?>
+
+                <?php if ($success): ?>
+                    <div class="alert alert-success"><?= Helpers::sanitize($success) ?></div>
+                <?php endif; ?>
+
+                <form method="post" class="vstack gap-3">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" role="switch" id="demo-mode" name="demo_mode_enabled" <?= $demoModeEnabled ? 'checked' : '' ?>>
+                        <label class="form-check-label" for="demo-mode">Demo modunu aktifleştir</label>
+                    </div>
+
+                    <div class="alert alert-info">
+                        <h6 class="alert-heading mb-2">Hazır Demo Kullanıcısı</h6>
+                        <ul class="mb-2">
+                            <li><strong>Kullanıcı adı:</strong> <?= Helpers::sanitize($demoCredentials['username']) ?></li>
+                            <li><strong>E-posta:</strong> <?= Helpers::sanitize($demoCredentials['email']) ?></li>
+                            <li><strong>Şifre:</strong> <?= Helpers::sanitize($demoCredentials['password']) ?></li>
+                        </ul>
+                        <p class="mb-0 small">Demo modunu aktifleştirdiğinizde hesap otomatik olarak oluşturulur veya güncellenir.</p>
+                    </div>
+
+                    <button type="submit" class="btn btn-primary align-self-start">Ayarları Kaydet</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<?php include __DIR__ . '/../templates/footer.php';

--- a/admin/settings-mail.php
+++ b/admin/settings-mail.php
@@ -4,7 +4,7 @@ require __DIR__ . '/../bootstrap.php';
 use App\Helpers;
 use App\Settings;
 
-if (empty($_SESSION['user']) || $_SESSION['user']['role'] !== 'admin') {
+if (empty($_SESSION['user']) || !in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
     Helpers::redirect('/');
 }
 

--- a/admin/support.php
+++ b/admin/support.php
@@ -4,7 +4,7 @@ require __DIR__ . '/../bootstrap.php';
 use App\Helpers;
 use App\Database;
 
-if (empty($_SESSION['user']) || $_SESSION['user']['role'] !== 'admin') {
+if (empty($_SESSION['user']) || !in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
     Helpers::redirect('/');
 }
 

--- a/admin/users.php
+++ b/admin/users.php
@@ -6,7 +6,7 @@ use App\Database;
 use App\Auth;
 use App\Mailer;
 
-if (empty($_SESSION['user']) || $_SESSION['user']['role'] !== 'admin') {
+if (empty($_SESSION['user']) || !in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
     Helpers::redirect('/');
 }
 

--- a/admin/woocommerce-import.php
+++ b/admin/woocommerce-import.php
@@ -5,7 +5,7 @@ use App\Database;
 use App\Helpers;
 use App\Importers\WooCommerceImporter;
 
-if (empty($_SESSION['user']) || $_SESSION['user']['role'] !== 'admin') {
+if (empty($_SESSION['user']) || !in_array($_SESSION['user']['role'], ['admin', 'demo'], true)) {
     Helpers::redirect('/');
 }
 

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -39,6 +39,26 @@ class Helpers
 
 
 
+    public static function isDemoModeEnabled(): bool
+    {
+        return defined('APP_DEMO_MODE_ENABLED') && APP_DEMO_MODE_ENABLED === true;
+    }
+
+    public static function isDemoUser(?array $user = null): bool
+    {
+        if ($user === null) {
+            if (session_status() !== PHP_SESSION_ACTIVE) {
+                session_start();
+            }
+
+            $user = $_SESSION['user'] ?? null;
+        }
+
+        return isset($user['role']) && $user['role'] === 'demo';
+    }
+
+    
+    
     public static function currentPath(): string
     {
         $uri = $_SERVER['REQUEST_URI'] ?? '/';

--- a/schema.sql
+++ b/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS users (
     name VARCHAR(150) NOT NULL,
     email VARCHAR(150) NOT NULL UNIQUE,
     password_hash VARCHAR(255) NOT NULL,
-    role ENUM('admin','reseller') NOT NULL DEFAULT 'reseller',
+    role ENUM('admin','reseller','demo') NOT NULL DEFAULT 'reseller',
     balance DECIMAL(12,2) NOT NULL DEFAULT 0,
     status ENUM('active','inactive') NOT NULL DEFAULT 'active',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/templates/header.php
+++ b/templates/header.php
@@ -10,53 +10,63 @@ $user = $_SESSION['user'] ?? null;
 $pageHeadline = $pageTitle ?? 'Panel';
 
 $menuSections = [];
+$adminMenuSections = [
+    [
+        'heading' => 'Genel',
+        'items' => [
+            ['label' => 'Genel Bakış', 'href' => '/admin/dashboard.php', 'pattern' => '/admin/dashboard.php', 'icon' => 'bi-speedometer2'],
+            ['label' => 'Paketler', 'href' => '/admin/packages.php', 'pattern' => '/admin/packages.php', 'icon' => 'bi-box-seam'],
+            ['label' => 'Siparişler', 'href' => '/admin/orders.php', 'pattern' => '/admin/orders.php', 'icon' => 'bi-receipt'],
+            ['label' => 'Bayiler', 'href' => '/admin/users.php', 'pattern' => '/admin/users.php', 'icon' => 'bi-people'],
+            ['label' => 'Raporlar', 'href' => '/admin/reports.php', 'pattern' => '/admin/reports.php', 'icon' => 'bi-graph-up'],
+        ],
+    ],
+    [
+        'heading' => 'Ürün Yönetimi',
+        'items' => [
+            ['label' => 'Ürünler & Kategoriler', 'href' => '/admin/products.php', 'pattern' => '/admin/products.php', 'icon' => 'bi-box'],
+            ['label' => 'WooCommerce İçe Aktar', 'href' => '/admin/woocommerce-import.php', 'pattern' => '/admin/woocommerce-import.php', 'icon' => 'bi-filetype-csv'],
+        ],
+    ],
+    [
+        'heading' => 'Finans & Destek',
+        'items' => [
+            ['label' => 'Bakiyeler', 'href' => '/admin/balances.php', 'pattern' => '/admin/balances.php', 'icon' => 'bi-cash-stack'],
+            ['label' => 'Destek', 'href' => '/admin/support.php', 'pattern' => '/admin/support.php', 'icon' => 'bi-life-preserver'],
+        ],
+    ],
+    [
+        'heading' => 'Ayarlar',
+        'items' => [
+            ['label' => 'Genel Ayarlar', 'href' => '/admin/settings-general.php', 'pattern' => '/admin/settings-general.php', 'icon' => 'bi-gear'],
+            ['label' => 'Mail Ayarları', 'href' => '/admin/settings-mail.php', 'pattern' => '/admin/settings-mail.php', 'icon' => 'bi-envelope-gear'],
+        ],
+    ],
+];
+
+$resellerMenuSections = [
+    [
+        'heading' => 'Bayi Paneli',
+        'items' => [
+            ['label' => 'Kontrol Paneli', 'href' => '/dashboard.php', 'pattern' => '/dashboard.php', 'icon' => 'bi-speedometer2'],
+            ['label' => 'Ürünler', 'href' => '/products.php', 'pattern' => '/products.php', 'icon' => 'bi-box'],
+            ['label' => 'Bakiyem', 'href' => '/balance.php', 'pattern' => '/balance.php', 'icon' => 'bi-wallet2'],
+            ['label' => 'Destek', 'href' => '/support.php', 'pattern' => '/support.php', 'icon' => 'bi-life-preserver'],
+        ],
+    ],
+];
 
 if ($user) {
     if ($user['role'] === 'admin') {
-        $menuSections = [
-            [
-                'heading' => 'Genel',
-                'items' => [
-                    ['label' => 'Genel Bakış', 'href' => '/admin/dashboard.php', 'pattern' => '/admin/dashboard.php', 'icon' => 'bi-speedometer2'],
-                    ['label' => 'Paketler', 'href' => '/admin/packages.php', 'pattern' => '/admin/packages.php', 'icon' => 'bi-box-seam'],
-                    ['label' => 'Siparişler', 'href' => '/admin/orders.php', 'pattern' => '/admin/orders.php', 'icon' => 'bi-receipt'],
-                    ['label' => 'Bayiler', 'href' => '/admin/users.php', 'pattern' => '/admin/users.php', 'icon' => 'bi-people'],
-                    ['label' => 'Raporlar', 'href' => '/admin/reports.php', 'pattern' => '/admin/reports.php', 'icon' => 'bi-graph-up'],
-                ],
-            ],
-            [
-                'heading' => 'Ürün Yönetimi',
-                'items' => [
-                    ['label' => 'Ürünler & Kategoriler', 'href' => '/admin/products.php', 'pattern' => '/admin/products.php', 'icon' => 'bi-box'],
-                    ['label' => 'WooCommerce İçe Aktar', 'href' => '/admin/woocommerce-import.php', 'pattern' => '/admin/woocommerce-import.php', 'icon' => 'bi-filetype-csv'],
-                ],
-            ],
-            [
-                'heading' => 'Finans & Destek',
-                'items' => [
-                    ['label' => 'Bakiyeler', 'href' => '/admin/balances.php', 'pattern' => '/admin/balances.php', 'icon' => 'bi-cash-stack'],
-                    ['label' => 'Destek', 'href' => '/admin/support.php', 'pattern' => '/admin/support.php', 'icon' => 'bi-life-preserver'],
-                ],
-            ],
-            [
-                'heading' => 'Ayarlar',
-                'items' => [
-                    ['label' => 'Mail Ayarları', 'href' => '/admin/settings-mail.php', 'pattern' => '/admin/settings-mail.php', 'icon' => 'bi-envelope-gear'],
-                ],
-            ],
-        ];
+        $menuSections = $adminMenuSections;
+    } elseif (Helpers::isDemoUser($user)) {
+        $demoSections = $resellerMenuSections;
+        if (isset($demoSections[0])) {
+            $demoSections[0]['heading'] = 'Bayi Deneyimi';
+        }
+        $menuSections = array_merge($adminMenuSections, $demoSections);
     } else {
-        $menuSections = [
-            [
-                'heading' => 'Bayi Paneli',
-                'items' => [
-                    ['label' => 'Kontrol Paneli', 'href' => '/dashboard.php', 'pattern' => '/dashboard.php', 'icon' => 'bi-speedometer2'],
-                    ['label' => 'Ürünler', 'href' => '/products.php', 'pattern' => '/products.php', 'icon' => 'bi-box'],
-                    ['label' => 'Bakiyem', 'href' => '/balance.php', 'pattern' => '/balance.php', 'icon' => 'bi-wallet2'],
-                    ['label' => 'Destek', 'href' => '/support.php', 'pattern' => '/support.php', 'icon' => 'bi-life-preserver'],
-                ],
-            ],
-        ];
+        $menuSections = $resellerMenuSections;
     }
 }
 ?>
@@ -74,12 +84,26 @@ if ($user) {
 <div class="app-shell">
     <?php if ($user): ?>
         <aside class="app-sidebar">
+            <?php
+            $sidebarDashboardLink = '/dashboard.php';
+            if (Helpers::isDemoUser($user) || ($user['role'] ?? null) === 'admin') {
+                $sidebarDashboardLink = '/admin/dashboard.php';
+            }
+            ?>
             <div class="sidebar-brand">
-                <a href="<?= $user['role'] === 'admin' ? '/admin/dashboard.php' : '/dashboard.php' ?>">Bayi Yönetim Sistemi</a>
+                <a href="<?= Helpers::sanitize($sidebarDashboardLink) ?>">Bayi Yönetim Sistemi</a>
             </div>
             <div class="sidebar-user">
                 <div class="sidebar-user-name"><?= Helpers::sanitize($user['name']) ?></div>
-                <div class="sidebar-user-role text-uppercase"><?= $user['role'] === 'admin' ? 'Yönetici' : 'Bayi' ?></div>
+                <div class="sidebar-user-role text-uppercase">
+                    <?php if (Helpers::isDemoUser($user)): ?>
+                        DEMO
+                    <?php elseif ($user['role'] === 'admin'): ?>
+                        Yönetici
+                    <?php else: ?>
+                        Bayi
+                    <?php endif; ?>
+                </div>
                 <div class="sidebar-user-balance">
                     Bakiye: <strong>$<?= number_format((float)$user['balance'], 2, '.', ',') ?></strong>
                 </div>
@@ -118,3 +142,21 @@ if ($user) {
             </header>
         <?php endif; ?>
         <main class="app-content flex-grow-1 container-fluid">
+            <?php
+            $demoNotice = $_SESSION['demo_notice'] ?? null;
+            if ($demoNotice):
+                unset($_SESSION['demo_notice']);
+            ?>
+                <div class="alert alert-danger mb-3">
+                    <?= Helpers::sanitize($demoNotice) ?>
+                </div>
+            <?php endif; ?>
+
+            <?php if ($user && Helpers::isDemoUser($user)): ?>
+                <div class="alert alert-warning d-flex align-items-center gap-2 mb-4">
+                    <i class="bi bi-eye fs-5"></i>
+                    <div>
+                        <strong>Demo modu etkin.</strong> Bu hesap yalnızca görüntüleme içindir ve yapılan değişiklikler kaydedilmez.
+                    </div>
+                </div>
+            <?php endif; ?>


### PR DESCRIPTION
## Summary
- add a general settings page that toggles demo mode and provisions the bundled demo credentials
- allow the demo role to authenticate in admin areas while blocking all write attempts across the app
- update navigation, schema, and helper utilities to recognise the demo role and surface read-only messaging

## Testing
- php -l app/Auth.php
- php -l bootstrap.php
- php -l admin/settings-general.php

------
https://chatgpt.com/codex/tasks/task_b_68dbe88596748321bb1643a7c95de477