### PR TITLE
Add demo mode toggle and read-only access

### DIFF
--- a/admin/settings-general.php
+++ b/admin/settings-general.php
@@ -4,6 +4,7 @@ require __DIR__ . '/../bootstrap.php';
 use App\Auth;
 use App\AuditLog;
 use App\Currency;
+use App\DemoMode;
 use App\FeatureToggle;
 use App\Helpers;
 use App\Settings;
@@ -23,6 +24,7 @@ $current = Settings::getMany(array(
     'reseller_auto_suspend_enabled',
     'reseller_auto_suspend_threshold',
     'reseller_auto_suspend_days',
+    'demo_mode_enabled',
 ));
 
 $featureLabels = array(
@@ -101,6 +103,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     Settings::set('reseller_auto_suspend_days', null);
                 }
 
+                $demoModeEnabled = isset($_POST['demo_mode_enabled']) ? '1' : '0';
+                Settings::set('demo_mode_enabled', $demoModeEnabled);
+                if ($demoModeEnabled === '1') {
+                    DemoMode::ensureUser();
+                } else {
+                    DemoMode::disableUser();
+                }
+
                 $success = 'Genel ayarlar kaydedildi.';
                 AuditLog::record(
                     $currentUser['id'],
@@ -119,6 +129,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'reseller_auto_suspend_enabled',
                     'reseller_auto_suspend_threshold',
                     'reseller_auto_suspend_days',
+                    'demo_mode_enabled',
                 ));
             }
         }
@@ -238,6 +249,18 @@ include __DIR__ . '/../templates/header.php';
                         </div>
                     </div>
 
+                    <div class="p-3 border rounded bg-light-subtle">
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" id="demoMode" name="demo_mode_enabled" <?= isset($current['demo_mode_enabled']) && $current['demo_mode_enabled'] === '1' ? 'checked' : '' ?>>
+                            <label class="form-check-label" for="demoMode">Demo kullanıcı oturumunu etkinleştir</label>
+                        </div>
+                        <p class="mb-2 small text-muted">Demo hesabı ile ziyaretçiler yönetici arayüzünü görüntüleyebilir ancak hiçbir değişiklik kaydedemez.</p>
+                        <ul class="small mb-0">
+                            <li>Kullanıcı adı: <code>demo</code></li>
+                            <li>E-posta: <code>demo@demo.com</code></li>
+                            <li>Şifre: <code>demo123!</code></li>
+                        </ul>
+                    </div>
                     <div class="d-flex justify-content-end">
                         <button type="submit" class="btn btn-primary">Ayarları Kaydet</button>
                     </div>

--- a/app/Auth.php
+++ b/app/Auth.php
@@ -4,6 +4,7 @@ namespace App;
 
 use App\Database;
 use App\Helpers;
+use App\Settings;
 use PDO;
 use RuntimeException;
 
@@ -16,6 +17,7 @@ class Auth
         'support' => 'Destek',
         'content' => 'İçerik',
         'reseller' => 'Bayi',
+        'demo' => 'Demo Kullanıcı',
     );
 
     /**
@@ -40,6 +42,10 @@ class Auth
      */
     public static function isAdminRole($role)
     {
+        if ($role === 'demo') {
+            return Settings::get('demo_mode_enabled') === '1';
+        }
+
         return in_array($role, self::adminRoles(), true);
     }
 
@@ -58,6 +64,20 @@ class Auth
 
         if (!is_array($roles)) {
             $roles = array($roles);
+        }
+
+        if ($role === 'demo') {
+            if (Settings::get('demo_mode_enabled') !== '1') {
+                return false;
+            }
+
+            foreach ($roles as $candidate) {
+                if ($candidate === 'demo' || self::isAdminRole($candidate)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         return in_array($role, $roles, true);
@@ -80,7 +100,15 @@ class Auth
 
         $user = isset($_SESSION['user']) ? $_SESSION['user'] : null;
 
-        if (!$user || !self::userHasRole($user, $roles)) {
+        if (!$user) {
+            Helpers::redirect($redirect);
+        }
+
+        if ($user['role'] === 'demo' && Settings::get('demo_mode_enabled') === '1') {
+            return;
+        }
+
+        if (!self::userHasRole($user, $roles)) {
             Helpers::redirect($redirect);
         }
     }
@@ -94,22 +122,18 @@ class Auth
         $role = is_array($actor) ? (isset($actor['role']) ? $actor['role'] : null) : $actor;
 
         if ($role === 'super_admin') {
-            return self::roles();
+            $assignable = self::roles();
+        } elseif ($role === 'admin') {
+            $assignable = array('admin', 'finance', 'support', 'content', 'reseller');
+        } elseif ($role === 'finance') {
+            $assignable = array('finance', 'support', 'reseller');
+        } elseif ($role === 'support' || $role === 'content') {
+            $assignable = array('support', 'content', 'reseller');
+        } else {
+            $assignable = array('reseller');
         }
 
-        if ($role === 'admin') {
-            return array('admin', 'finance', 'support', 'content', 'reseller');
-        }
-
-        if ($role === 'finance') {
-            return array('finance', 'support', 'reseller');
-        }
-
-        if ($role === 'support' || $role === 'content') {
-            return array('support', 'content', 'reseller');
-        }
-
-        return array('reseller');
+        return array_values(array_diff($assignable, array('demo')));
     }
 
     /**
@@ -137,6 +161,10 @@ class Auth
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
         if ($user && password_verify($password, $user['password_hash'])) {
+            if ($user['role'] === 'demo' && Settings::get('demo_mode_enabled') !== '1') {
+                return null;
+            }
+
             return $user;
         }
 

--- a/app/DemoMode.php
+++ b/app/DemoMode.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App;
+
+use PDO;
+
+class DemoMode
+{
+    private const DEMO_NAME = 'demo';
+    private const DEMO_EMAIL = 'demo@demo.com';
+    private const DEMO_PASSWORD = 'demo123!';
+
+    /**
+     * @return bool
+     */
+    public static function isEnabled()
+    {
+        return Settings::get('demo_mode_enabled') === '1';
+    }
+
+    /**
+     * Ensure the demo user exists and matches the expected credentials when demo mode is active.
+     *
+     * @return void
+     */
+    public static function ensureUser()
+    {
+        if (!self::isEnabled()) {
+            self::disableUser();
+
+            return;
+        }
+
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT id, name, email, status, password_hash FROM users WHERE role = :role LIMIT 1');
+        $stmt->execute(array('role' => 'demo'));
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$user) {
+            Auth::createUser(self::DEMO_NAME, self::DEMO_EMAIL, self::DEMO_PASSWORD, 'demo', 0);
+
+            return;
+        }
+
+        $fields = array();
+        $params = array('id' => (int)$user['id']);
+
+        if (!isset($user['name']) || $user['name'] !== self::DEMO_NAME) {
+            $fields[] = 'name = :name';
+            $params['name'] = self::DEMO_NAME;
+        }
+
+        if (!isset($user['email']) || $user['email'] !== self::DEMO_EMAIL) {
+            $fields[] = 'email = :email';
+            $params['email'] = self::DEMO_EMAIL;
+        }
+
+        if (!isset($user['status']) || $user['status'] !== 'active') {
+            $fields[] = "status = 'active'";
+        }
+
+        if (!isset($user['password_hash']) || !password_verify(self::DEMO_PASSWORD, $user['password_hash'])) {
+            $fields[] = 'password_hash = :password_hash';
+            $params['password_hash'] = password_hash(self::DEMO_PASSWORD, PASSWORD_BCRYPT);
+        }
+
+        if ($fields) {
+            $fields[] = 'updated_at = NOW()';
+            $sql = 'UPDATE users SET ' . implode(', ', $fields) . ' WHERE id = :id';
+            $update = $pdo->prepare($sql);
+            $update->execute($params);
+        }
+    }
+
+    /**
+     * Disable demo users when the feature is turned off.
+     *
+     * @return void
+     */
+    public static function disableUser()
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare("UPDATE users SET status = 'inactive', updated_at = NOW() WHERE role = :role");
+        $stmt->execute(array('role' => 'demo'));
+    }
+
+    /**
+     * Guard demo sessions against state-changing requests.
+     *
+     * @param array $user
+     * @return void
+     */
+    public static function guard(array $user)
+    {
+        if (!isset($user['role']) || $user['role'] !== 'demo') {
+            return;
+        }
+
+        if (!self::isEnabled()) {
+            unset($_SESSION['user']);
+            $_SESSION['flash_warning'] = 'Demo modu devre dışı bırakıldığı için oturum sonlandırıldı.';
+            Helpers::redirect('/index.php');
+        }
+
+        $method = isset($_SERVER['REQUEST_METHOD']) ? strtoupper($_SERVER['REQUEST_METHOD']) : 'GET';
+        if (in_array($method, array('GET', 'HEAD', 'OPTIONS'), true)) {
+            return;
+        }
+
+        $targetPath = null;
+
+        if (!empty($_SERVER['HTTP_REFERER'])) {
+            $refererPath = parse_url($_SERVER['HTTP_REFERER'], PHP_URL_PATH);
+            if (is_string($refererPath) && $refererPath !== '') {
+                $targetPath = $refererPath;
+            }
+        }
+
+        if (!$targetPath && !empty($_SERVER['REQUEST_URI'])) {
+            $targetPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+        }
+
+        $redirectPath = Helpers::normalizeRedirectPath($targetPath, '/dashboard.php');
+        Helpers::setFlash('errors', array('Demo hesabı ile değişiklik yapılamaz.'));
+        Helpers::redirect($redirectPath);
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -109,4 +109,6 @@ if (!empty($_SESSION['user'])) {
     if ($preferredLanguage) {
         App\Lang::setLocale($preferredLanguage);
     }
+
+    App\DemoMode::guard($_SESSION['user']);
 }

--- a/schema.sql
+++ b/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS users (
     name VARCHAR(150) NOT NULL,
     email VARCHAR(150) NOT NULL UNIQUE,
     password_hash VARCHAR(255) NOT NULL,
-    role ENUM('super_admin','admin','finance','support','content','reseller') NOT NULL DEFAULT 'reseller',
+    role ENUM('super_admin','admin','finance','support','content','reseller','demo') NOT NULL DEFAULT 'reseller',
     balance DECIMAL(12,2) NOT NULL DEFAULT 0,
     status ENUM('active','inactive') NOT NULL DEFAULT 'active',
     low_balance_since DATETIME NULL DEFAULT NULL,


### PR DESCRIPTION
## Summary
- add a toggle in general settings to enable or disable a seeded demo account with published credentials
- support a dedicated demo role with read-only guard logic during authentication and bootstrap
- update the database schema to include the demo role value

## Testing
- php -l app/Auth.php
- php -l app/DemoMode.php
- php -l admin/settings-general.php
- php -l bootstrap.php

------
https://chatgpt.com/codex/tasks/task_b_68dc0884e49483218b224ce6ac35637f