### PR TITLE
Integrate Lotus API into product ordering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+LOTUS_API_KEY=__PUT_YOUR_KEY__
+LOTUS_BASE_URL=https://partner.lotuslisans.com.tr

--- a/README.md
+++ b/README.md
@@ -58,5 +58,236 @@ Profesyonel bayilik yönetim süreçlerinizi uçtan uca yönetebilmeniz için ge
 - `config/config.php` dosyası git tarafından izlenmez; dağıtıma özel yapılandırmalar için bu dosya kullanılır.
 - Arayüz Bootstrap CDN üzerinden yüklenir. Ek CSS düzenlemeleri `assets/css/style.css` üzerinden yapılabilir.
 
+## Lotus Lisans Partner API PHP SDK
+
+Bu depo, Lotus Lisans Partner API için üretim kalitesinde küçük bir PHP SDK ve örnek komut satırı betiği de içerir. SDK, Guzzle tabanlı HTTP istemcisi, otomatik yeniden deneme/backoff politikası, tutarlı bir hata modeli ve `.env` ile yapılandırılabilir ortam değişkeni desteği sağlar.
+
+### Kurulum
+
+SDK bağımlılıklarını yüklemek için kök dizinde aşağıdaki komutu çalıştırın:
+
+```
+composer require guzzlehttp/guzzle vlucas/phpdotenv ramsey/uuid
+```
+
+Ardından `.env.example` dosyasını `.env` olarak kopyalayarak API anahtarınızı ekleyin:
+
+```
+cp .env.example .env
+```
+
+### Kullanım
+
+1. Gerekli yapılandırmaları `.env` dosyasına girin (`LOTUS_API_KEY`, isteğe bağlı `LOTUS_BASE_URL`).
+2. Örnek betiği çalıştırın:
+
+   ```bash
+   php examples/demo.php
+   ```
+
+`Lotus\Client` sınıfı varsayılan olarak API anahtarını `X-API-Key` başlığında gönderir ve her istekte benzersiz bir `X-Request-Id` üretir. `useQueryApiKey` seçeneği `true` yapılabilir ancak güvenlik nedeniyle sorgu parametresiyle kimlik doğrulamayı yalnızca zorunlu durumlarda kullanmanız önerilir.
+
+### Hata Yakalama ve Yeniden Deneme
+
+Tüm hata durumlarında `Lotus\Exceptions\ApiError` fırlatılır. Bu sınıf HTTP durum kodu, isteğe ait `X-Request-Id`, opsiyonel hata kodu ve ham yanıt gövdesini içerir. İstemci 429 ve 5xx yanıtları için varsayılan olarak üç deneme hakkına sahip exponential backoff (jitter'lı) stratejisi uygular. `maxRetries` ve `retryBaseMs` parametreleri ile davranışı özelleştirebilirsiniz.
+
+### Yardımcı Özellikler
+
+- `ResponseTypes` yardımcı sınıfı, API'nin `amount` ve `credit` alanlarını güvenle `float` tipine dönüştürür.
+- `created_at` alanı bulunduğunda otomatik olarak `created_at_dt` anahtarı altında `DateTimeImmutable` nesnesi eklenir.
+- Liste uç noktalarında sayfalama bilgisi (`meta.page`, `meta.per_page`, `meta.count`) yoksa otomatik olarak oluşturulur.
+- `Client::getLastRequestId()` ile son isteğin izleme kimliğine erişebilirsiniz.
+
+### API Dokümantasyonu
+
+Aşağıdaki bölüm, Lotus Lisans Partner API'nin resmi uç noktalarını ve yanıt biçimlerini içerir.
+
+Bu doküman, canlı ortamda kullanılan API uç noktalarını ve geri dönüş biçimlerini detaylı olarak açıklamaktadır. Tüm örnekler, en son yayınlanan kod tabanına uygun olarak hazırlanmıştır. Temel API adresi: https://partner.lotuslisans.com.tr
+
+#### Kimlik Doğrulama (Authentication)
+Tüm uç noktalar, yetkisiz erişimi önlemek amacıyla bir API Anahtarıile korunmaktadır. API anahtarınızı aşağıdaki iki yöntemden birini kullanarak sağlamanız zorunludur:
+- Sorgu Parametresi: ?apikey=YOUR_KEY
+- Header: X-API-Key: YOUR_KEY
+
+Geçersiz veya Eksik Anahtar Durumu: İstek, 401 UnauthorizedHTTP durum kodu ile sonuçlanacaktır.
+
+#### Durum Kodları ve Sipariş "status" Alanı
+Genel HTTP Durum Kodları Özeti
+
+| Kod | Anlamı | Açıklama |
+|-----|--------|----------|
+| 200 | Başarılı | İstek başarıyla işlendi ve beklenen yanıt döndürüldü. |
+| 400 | İş Kuralı Hatası | İstek geçerli, ancak bakiye yetersizliği, doğrulama hatası gibi bir iş kuralı nedeniyle işlenemedi. |
+| 401 | Yetkisiz | API anahtarı geçersiz veya eksik. |
+| 404 | Bulunamadı | İstenen kaynak (ürün, sipariş vb.) bulunamadı. |
+| 500 | Sunucu Hatası | Sunucu tarafında beklenmeyen bir hata oluştu. |
+
+Sipariş Durumu Metinleri ("status" Alanı)
+
+| Değer | Anlamı | Açıklama |
+|--------|--------|----------|
+| completed | Teslim Edildi (Stoklu) | Sipariş, stoktan anında düşülerek başarılı bir şekilde tamamlanmıştır. İçerik (content) alanı teslim edilen bilgiyi içerir. |
+| pending | Beklemede (Stoksuz) | Ürün stoğu yetersizdi veya stoksuz satışa açıktı. Sipariş, sonradan teslim edilmek üzere sıraya alınmıştır. İçerik (content) alanında bilgilendirme mesajı bulunur. |
+| cancelled | İptal Edildi | Sipariş, yönetim paneli üzerinden iptal edilmiştir. |
+| failed | Başarısız | Yalnızca Sipariş Oluşturma denemelerinde döner. İş kuralı (bakiye yetersizliği gibi) veya sistemsel bir hata nedeniyle oluşturulamamıştır. |
+
+#### API Uç Noktaları
+
+1. **Kullanıcı Bilgisi** — `GET /api/user`
+   - Kimlik doğrulama parametresi: `apikey` veya `X-API-Key`
+   - Başarılı 200 Yanıt:
+
+     ```json
+     {
+       "success": true,
+       "data": {
+         "credit": "750",
+         "nickname": "user",
+         "email": "user@admin.com"
+       }
+     }
+     ```
+
+2. **Ürün Listesi** — `GET /api/products`
+   - Notlar:
+     - `stock`: Teslim edilmemiş (delivery=1) satır sayısını gösterir.
+     - `available`: true ise ürün anında teslim için stokludur veya stoksuz satışa açıktır.
+   - Başarılı 200 Yanıt (kısaltılmış):
+
+     ```json
+     {
+       "success": true,
+       "data": [
+         {
+           "id": 20,
+           "title": "Office 2021 Pro Plus - Retail (Telefon Aktivasyon)",
+           "content": "Key olarak teslim edilir...",
+           "amount": "50",
+           "stock": 11,
+           "available": true
+         }
+       ]
+     }
+     ```
+
+3. **Sipariş Oluşturma** — `POST /api/orders`
+   - JSON Gövdesi:
+     - `product_id` (int, zorunlu)
+     - `note` (string, opsiyonel)
+   - Önemli Not: Aynı ürün için art arda POST isteği atıldığında, her istek ayrı bir sipariş olarak işlenir.
+   - Başarılı Yanıt Örnekleri:
+
+     ```json
+     {
+       "success": true,
+       "data": {
+         "order_id": 48380,
+         "status": "completed",
+         "content": "STOK_ICERIK_KEY_XXX"
+       }
+     }
+     ```
+
+     ```json
+     {
+       "success": true,
+       "data": {
+         "order_id": 48381,
+         "status": "pending",
+         "content": "Siparişiniz hazır olduğunda telegram bildirimi alacaksınız."
+       }
+     }
+     ```
+
+   - Hata Yanıtları:
+
+     ```json
+     {
+       "success": false,
+       "status": "failed",
+       "message": "Yeterli bakiyeniz yok."
+     }
+     ```
+
+     ```json
+     {
+       "success": false,
+       "status": "failed",
+       "message": "Ürün bulunamadı."
+     }
+     ```
+
+     ```json
+     {
+       "success": false,
+       "status": "failed",
+       "message": "Sipariş sırasında hata oluştu."
+     }
+     ```
+
+4. **Sipariş Geçmişi** — `GET /api/orders`
+   - Başarılı 200 Yanıt (kısaltılmış):
+
+     ```json
+     {
+       "success": true,
+       "data": [
+         {
+           "id": 48380,
+           "product_id": "29",
+           "product_title": "Adobe CC - 2 Hafta",
+           "amount": "40",
+           "note": "müşterinin kendi girdiği not",
+           "content": "STOK_ICERIK_KEY_XXX",
+           "status": "completed",
+           "source": "api",
+           "created_at": "2025-10-02T00:06:25.000000Z"
+         }
+       ]
+     }
+     ```
+
+5. **Sipariş Detayı** — `GET /api/orders/{id}`
+   - Başarılı 200 Yanıt:
+
+     ```json
+     {
+       "success": true,
+       "data": {
+         "id": 48380,
+         "product_id": "29",
+         "product_title": "Adobe CC - 2 Hafta",
+         "amount": "40",
+         "note": "müşterinin kendi girdiği not",
+         "content": "STOK_ICERIK_KEY_XXX",
+         "status": "completed",
+         "source": "api",
+         "created_at": "2025-10-02T00:06:25.000000Z"
+       }
+     }
+     ```
+
+   - 404 Hata Yanıtı:
+
+     ```json
+     {
+       "success": false,
+       "message": "Sipariş bulunamadı."
+     }
+     ```
+
+#### İçerik Formatı Notları
+- Stoklu içerikler: `content` alanı teslim edilen stok bilgisini satır sonları korunarak döndürür.
+- `pending` siparişler: `content` alanı bilgilendirme mesajı içerir; teslim sonrası güncellenir.
+- `cancelled` siparişler: `content` alanı iptal durumunu yansıtır.
+
+#### İdempotensi
+İdempotensi anahtarı zorunlu değildir. Aynı isteğin tekrarlanması her defasında yeni bir sipariş oluşturur. SDK, gelecekteki uyumluluk için `Idempotency-Key` başlığını isteğe bağlı olarak göndermenizi destekler.
+
+#### Postman İçin Hızlı Örnekler
+- `POST https://partner.lotuslisans.com.tr/api/orders?apikey=TEST_KEY`
+- `GET https://partner.lotuslisans.com.tr/api/orders`
+- `GET https://partner.lotuslisans.com.tr/api/orders/48380`
+
 ## Lisans
 Bu proje MIT Lisansı ile lisanslanmıştır. Ayrıntılar için `LICENSE` dosyasına göz atın.

--- a/app/Services/LotusPartnerApi.php
+++ b/app/Services/LotusPartnerApi.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Services;
+
+use App\Settings;
+use Lotus\Client as LotusClient;
+use RuntimeException;
+
+class LotusPartnerApi
+{
+    public static function isEnabled(): bool
+    {
+        return Settings::get('lotus_api_enabled') === '1';
+    }
+
+    public static function createClient(): LotusClient
+    {
+        if (!self::isEnabled()) {
+            throw new RuntimeException('Lotus API integration is disabled.');
+        }
+
+        $apiKey = Settings::get('lotus_api_key');
+        if ($apiKey === null || $apiKey === '') {
+            throw new RuntimeException('Lotus API anahtarı yapılandırılmadı.');
+        }
+
+        $baseUrl = Settings::get('lotus_base_url');
+        $useQuery = Settings::get('lotus_use_query_api_key') === '1';
+        $timeoutSetting = Settings::get('lotus_timeout');
+
+        $options = [
+            'apiKey' => $apiKey,
+        ];
+
+        if ($baseUrl && $baseUrl !== '') {
+            $options['baseUrl'] = $baseUrl;
+        }
+
+        if ($useQuery) {
+            $options['useQueryApiKey'] = true;
+        }
+
+        if ($timeoutSetting !== null && $timeoutSetting !== '') {
+            $timeout = (float) $timeoutSetting;
+            if ($timeout > 0) {
+                $options['timeout'] = $timeout;
+            }
+        }
+
+        return new LotusClient($options);
+    }
+
+    /**
+     * @param array<string, mixed> $product
+     * @throws RuntimeException
+     */
+    public static function resolveRemoteProductId(array $product): int
+    {
+        if (!isset($product['sku']) || $product['sku'] === null || $product['sku'] === '') {
+            throw new RuntimeException('Lotus ürün ID bilgisi için ürün SKU alanını doldurun.');
+        }
+
+        $sku = (string) $product['sku'];
+        $normalized = trim($sku);
+
+        if ($normalized === '' || !preg_match('/^\d+$/', $normalized)) {
+            throw new RuntimeException('Lotus ürün ID\'si SKU alanında yalnızca rakamlardan oluşmalıdır.');
+        }
+
+        return (int) $normalized;
+    }
+
+    /**
+     * @param array<string, mixed> $product
+     * @return array{
+     *     status: string,
+     *     external_reference: string|null,
+     *     metadata: array<string, mixed>
+     * }
+     */
+    public static function submitProductOrder(array $product, int $quantity = 1, ?string $note = null): array
+    {
+        $client = self::createClient();
+        $remoteProductId = self::resolveRemoteProductId($product);
+        $quantity = max(1, $quantity);
+
+        $responses = [];
+        $statuses = [];
+        $orderIds = [];
+
+        for ($index = 1; $index <= $quantity; $index++) {
+            $body = [
+                'product_id' => $remoteProductId,
+            ];
+
+            if ($note !== null && $note !== '') {
+                $body['note'] = $quantity > 1
+                    ? sprintf('[%d/%d] %s', $index, $quantity, $note)
+                    : $note;
+            }
+
+            $response = $client->createOrder($body);
+            $responses[] = $response;
+
+            $data = isset($response['data']) && is_array($response['data']) ? $response['data'] : [];
+            if (isset($data['status']) && is_string($data['status'])) {
+                $statuses[] = strtolower($data['status']);
+            }
+
+            if (isset($data['order_id'])) {
+                $orderIds[] = (string) $data['order_id'];
+            } elseif (isset($data['id'])) {
+                $orderIds[] = (string) $data['id'];
+            }
+        }
+
+        $localStatus = self::mapStatuses($statuses);
+        $reference = self::buildReference($orderIds);
+
+        $metadata = [
+            'lotus' => [
+                'product_id' => $remoteProductId,
+                'orders' => $responses,
+            ],
+        ];
+
+        return [
+            'status' => $localStatus,
+            'external_reference' => $reference,
+            'metadata' => $metadata,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public static function encodeMetadata(array $metadata): string
+    {
+        $json = json_encode($metadata, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            throw new RuntimeException('Lotus metadata JSON üretilemedi: ' . json_last_error_msg());
+        }
+
+        return $json;
+    }
+
+    /**
+     * @param array<int, string> $statuses
+     */
+    private static function mapStatuses(array $statuses): string
+    {
+        if (!$statuses) {
+            return 'processing';
+        }
+
+        $hasCompleted = false;
+        $hasPending = false;
+        $hasCancelled = false;
+
+        foreach ($statuses as $status) {
+            switch ($status) {
+                case 'completed':
+                    $hasCompleted = true;
+                    break;
+                case 'cancelled':
+                    $hasCancelled = true;
+                    break;
+                default:
+                    $hasPending = true;
+                    break;
+            }
+        }
+
+        if ($hasCancelled && !$hasCompleted && !$hasPending) {
+            return 'cancelled';
+        }
+
+        if ($hasCompleted && !$hasPending && !$hasCancelled) {
+            return 'completed';
+        }
+
+        if ($hasCompleted && ($hasPending || $hasCancelled)) {
+            return 'processing';
+        }
+
+        if ($hasPending) {
+            return 'processing';
+        }
+
+        if ($hasCancelled) {
+            return 'cancelled';
+        }
+
+        return 'processing';
+    }
+
+    /**
+     * @param array<int, string> $orderIds
+     */
+    private static function buildReference(array $orderIds): ?string
+    {
+        if (!$orderIds) {
+            return null;
+        }
+
+        if (count($orderIds) === 1) {
+            return 'LOTUS#' . $orderIds[0];
+        }
+
+        $first = array_shift($orderIds);
+        $additional = count($orderIds);
+
+        return sprintf('LOTUS#%s +%d', $first, $additional);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "lotus/partner-sdk-example",
+    "description": "PHP 8.1+ Lotus Lisans Partner API SDK and example usage.",
+    "type": "library",
+    "require": {
+        "php": "^8.1",
+        "guzzlehttp/guzzle": "^7.9",
+        "vlucas/phpdotenv": "^5.6",
+        "ramsey/uuid": "^4.7"
+    },
+    "autoload": {
+        "psr-4": {
+            "Lotus\\": "src/Lotus/"
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}

--- a/examples/demo.php
+++ b/examples/demo.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Dotenv\Dotenv;
+use Lotus\Client;
+use Lotus\Exceptions\ApiError;
+
+$dotenv = Dotenv::createImmutable(__DIR__ . '/..');
+$dotenv->safeLoad();
+
+$client = new Client([
+    // 'apiKey' => 'your-api-key',
+    // 'baseUrl' => 'https://partner.lotuslisans.com.tr',
+    // 'useQueryApiKey' => false,
+]);
+
+try {
+    $me = $client->getUser();
+    $credit = $me['data']['credit'] ?? $me['credit'] ?? null;
+    if ($credit !== null) {
+        echo 'Credit: ' . $credit . PHP_EOL;
+    }
+
+    $products = $client->listProducts();
+    $firstAvailable = null;
+    foreach (($products['data'] ?? []) as $product) {
+        if (($product['available'] ?? false) === true) {
+            $firstAvailable = $product;
+            break;
+        }
+    }
+
+    if ($firstAvailable) {
+        $order = $client->createOrder([
+            'product_id' => (int) ($firstAvailable['id'] ?? 0),
+            'note' => 'müşteri notu',
+        ]);
+
+        print_r($order);
+
+        $orderId = $order['data']['order_id'] ?? $order['data']['id'] ?? null;
+        if ($orderId) {
+            $detail = $client->getOrderById((int) $orderId);
+            print_r($detail);
+        }
+    }
+
+    $orders = $client->listOrders(['status' => 'completed']);
+    echo 'Completed orders: ' . count($orders['data'] ?? []) . PHP_EOL;
+} catch (ApiError $e) {
+    fwrite(STDERR, sprintf("API Error (%d): %s\n", $e->httpStatus, $e->getMessage()));
+    if ($e->requestId) {
+        fwrite(STDERR, sprintf("X-Request-Id: %s\n", $e->requestId));
+    }
+    if (!empty($e->details)) {
+        fwrite(STDERR, "Details: " . json_encode($e->details, JSON_PRETTY_PRINT) . PHP_EOL);
+    }
+}

--- a/src/Lotus/Client.php
+++ b/src/Lotus/Client.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotus;
+
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Lotus\Exceptions\ApiError;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Ramsey\Uuid\Uuid;
+
+class Client
+{
+    private HttpClient $httpClient;
+    private ?string $apiKey;
+    private string $baseUrl;
+    private float $timeout;
+    private bool $useQueryApiKey;
+    private int $maxRetries;
+    private int $retryBaseMs;
+    private ?string $lastRequestId = null;
+
+    public function __construct(array $opts = [])
+    {
+        $this->apiKey = $opts['apiKey'] ?? $_ENV['LOTUS_API_KEY'] ?? null;
+        $this->baseUrl = rtrim($opts['baseUrl'] ?? $_ENV['LOTUS_BASE_URL'] ?? 'https://partner.lotuslisans.com.tr', '/');
+        $this->timeout = (float) ($opts['timeout'] ?? 20.0);
+        $this->useQueryApiKey = (bool) ($opts['useQueryApiKey'] ?? false);
+        $this->maxRetries = (int) ($opts['maxRetries'] ?? 3);
+        $this->retryBaseMs = (int) ($opts['retryBaseMs'] ?? 250);
+
+        $handlerStack = HandlerStack::create();
+        $handlerStack->push($this->createRetryMiddleware());
+
+        $this->httpClient = new HttpClient([
+            'base_uri' => $this->baseUrl,
+            'timeout' => $this->timeout,
+            'handler' => $handlerStack,
+            'http_errors' => false,
+        ]);
+    }
+
+    public function getLastRequestId(): ?string
+    {
+        return $this->lastRequestId;
+    }
+
+    public function getUser(): array
+    {
+        $response = $this->request('GET', '/api/user');
+
+        return $response;
+    }
+
+    public function listProducts(array $params = []): array
+    {
+        $response = $this->request('GET', '/api/products', [
+            'query' => $this->normalizeListParams($params),
+        ]);
+
+        return ResponseTypes::applyListMeta($response, $params);
+    }
+
+    public function createOrder(array $body, array $opts = []): array
+    {
+        $idempotencyKey = isset($opts['idempotencyKey']) && $opts['idempotencyKey'] !== ''
+            ? (string) $opts['idempotencyKey']
+            : null;
+
+        $response = $this->request('POST', '/api/orders', [
+            'json' => $body,
+        ], $idempotencyKey);
+
+        return $response;
+    }
+
+    public function listOrders(array $params = []): array
+    {
+        $response = $this->request('GET', '/api/orders', [
+            'query' => $this->normalizeListParams($params),
+        ]);
+
+        return ResponseTypes::applyListMeta($response, $params);
+    }
+
+    public function getOrderById(int $id): array
+    {
+        $response = $this->request('GET', sprintf('/api/orders/%d', $id));
+
+        return $response;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function request(string $method, string $path, array $options = [], ?string $idempotencyKey = null): array
+    {
+        if ($this->apiKey === null || $this->apiKey === '') {
+            throw new ApiError('Lotus API key is not configured. Provide it via constructor or LOTUS_API_KEY env.');
+        }
+
+        $requestUuid = Uuid::uuid4()->toString();
+
+        $headers = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+            'X-Request-Id' => $requestUuid,
+        ];
+
+        if (!$this->useQueryApiKey) {
+            $headers['X-API-Key'] = $this->apiKey;
+        }
+
+        if ($idempotencyKey !== null) {
+            $headers['Idempotency-Key'] = $idempotencyKey;
+        }
+
+        if (isset($options['headers'])) {
+            $headers = array_merge($headers, $options['headers']);
+        }
+
+        $options['headers'] = $headers;
+
+        $query = $options['query'] ?? [];
+        if ($this->useQueryApiKey) {
+            $query['apikey'] = $this->apiKey;
+        }
+
+        if (!empty($query)) {
+            $options['query'] = $query;
+        }
+
+        try {
+            $response = $this->httpClient->request($method, $path, $options);
+        } catch (GuzzleException $exception) {
+            throw new ApiError(
+                sprintf('Lotus API request error: %s', $exception->getMessage()),
+                0,
+                null,
+                [],
+                $requestUuid,
+                $exception
+            );
+        }
+
+        $this->lastRequestId = $response->getHeaderLine('X-Request-Id') ?: $requestUuid;
+
+        return $this->handleResponse($response);
+    }
+
+    private function handleResponse(ResponseInterface $response): array
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        $requestId = $response->getHeaderLine('X-Request-Id') ?: $this->lastRequestId;
+
+        $decoded = null;
+        if ($body !== '') {
+            $decoded = json_decode($body, true);
+        }
+
+        if ($decoded === null && $body !== '' && json_last_error() !== JSON_ERROR_NONE) {
+            if ($status >= 400) {
+                throw new ApiError(
+                    'Lotus API returned a non-JSON error response.',
+                    $status,
+                    null,
+                    ['raw' => $body],
+                    $requestId
+                );
+            }
+
+            return [
+                'success' => true,
+                'data' => $body,
+                'request_id' => $requestId,
+                'status' => $status,
+            ];
+        }
+
+        $payload = is_array($decoded) ? $decoded : [];
+
+        $isError = $status >= 400
+            || (isset($payload['success']) && $payload['success'] === false);
+
+        if ($isError) {
+            $message = $payload['message'] ?? $response->getReasonPhrase() ?: 'Lotus API request failed.';
+            $code = null;
+            if (isset($payload['code']) && is_string($payload['code'])) {
+                $code = $payload['code'];
+            } elseif (isset($payload['status']) && is_string($payload['status'])) {
+                $code = $payload['status'];
+            }
+
+            throw new ApiError(
+                $message,
+                $status,
+                $code,
+                $payload,
+                $requestId
+            );
+        }
+
+        $payload = ResponseTypes::normalizeNumericValues($payload);
+        $payload = ResponseTypes::appendCreatedAtDateTime($payload);
+
+        if (!isset($payload['request_id'])) {
+            $payload['request_id'] = $requestId;
+        }
+
+        if (!isset($payload['status'])) {
+            $payload['status'] = $status;
+        }
+
+        return $payload;
+    }
+
+    private function normalizeListParams(array $params): array
+    {
+        $allowed = ['page', 'per_page', 'status', 'date_from', 'date_to', 'product_id'];
+        $normalized = [];
+        foreach ($params as $key => $value) {
+            if (!in_array($key, $allowed, true)) {
+                continue;
+            }
+
+            if (in_array($key, ['page', 'per_page', 'product_id'], true)) {
+                $normalized[$key] = (int) $value;
+                continue;
+            }
+
+            if ($key === 'status' && is_string($value)) {
+                $normalized[$key] = $value;
+                continue;
+            }
+
+            if (in_array($key, ['date_from', 'date_to'], true) && is_string($value)) {
+                $normalized[$key] = $value;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function createRetryMiddleware(): callable
+    {
+        return Middleware::retry(
+            function (int $retries, RequestInterface $request, ?ResponseInterface $response, ?RequestException $exception): bool {
+                if ($retries >= $this->maxRetries) {
+                    return false;
+                }
+
+                if ($response instanceof ResponseInterface) {
+                    $status = $response->getStatusCode();
+                    if ($status === 429 || ($status >= 500 && $status < 600)) {
+                        return true;
+                    }
+                }
+
+                if ($exception instanceof ConnectException) {
+                    return true;
+                }
+
+                return false;
+            },
+            function (int $retries): int {
+                if ($retries <= 0) {
+                    return 0;
+                }
+
+                $base = $this->retryBaseMs * (2 ** ($retries - 1));
+                $jitterMax = max(1, (int) floor($this->retryBaseMs / 2));
+                $jitter = random_int(0, $jitterMax);
+
+                return (int) $base + $jitter;
+            }
+        );
+    }
+}

--- a/src/Lotus/Exceptions/ApiError.php
+++ b/src/Lotus/Exceptions/ApiError.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotus\Exceptions;
+
+class ApiError extends \RuntimeException
+{
+    public int $httpStatus;
+    public ?string $apiCode;
+    public array $details;
+    public ?string $requestId;
+
+    public function __construct(
+        string $message,
+        int $httpStatus = 0,
+        ?string $code = null,
+        array $details = [],
+        ?string $requestId = null,
+        ?\Throwable $previous = null
+    ) {
+        parent::__construct($message, 0, $previous);
+        $this->httpStatus = $httpStatus;
+        $this->apiCode = $code;
+        $this->details = $details;
+        $this->requestId = $requestId;
+    }
+
+    public function getApiCode(): ?string
+    {
+        return $this->apiCode;
+    }
+
+    public function __get(string $name): mixed
+    {
+        if ($name === 'code') {
+            return $this->apiCode;
+        }
+
+        trigger_error(sprintf('Undefined property: %s::$%s', static::class, $name), E_USER_NOTICE);
+
+        return null;
+    }
+}

--- a/src/Lotus/ResponseTypes.php
+++ b/src/Lotus/ResponseTypes.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lotus;
+
+final class ResponseTypes
+{
+    /**
+     * Normalize numeric string values commonly returned by the API.
+     *
+     * @param mixed $payload
+     * @return mixed
+     */
+    public static function normalizeNumericValues(mixed $payload): mixed
+    {
+        if (is_array($payload)) {
+            foreach ($payload as $key => $value) {
+                if (is_array($value)) {
+                    $payload[$key] = self::normalizeNumericValues($value);
+                    continue;
+                }
+
+                if (is_string($value) && ($key === 'amount' || $key === 'credit')) {
+                    $payload[$key] = self::safeFloatval($value);
+                }
+            }
+        }
+
+        return $payload;
+    }
+
+    public static function appendCreatedAtDateTime(array $payload): array
+    {
+        if (isset($payload['data'])) {
+            $payload['data'] = self::transformCreatedAt($payload['data']);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param mixed $data
+     * @return mixed
+     */
+    private static function transformCreatedAt(mixed $data): mixed
+    {
+        if (is_array($data)) {
+            if (self::isAssoc($data)) {
+                if (isset($data['created_at']) && is_string($data['created_at'])) {
+                    $data['created_at_dt'] = self::toDateTimeImmutable($data['created_at']);
+                }
+
+                foreach ($data as $key => $value) {
+                    $data[$key] = self::transformCreatedAt($value);
+                }
+            } else {
+                foreach ($data as $index => $value) {
+                    $data[$index] = self::transformCreatedAt($value);
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    public static function toDateTimeImmutable(?string $value): ?\DateTimeImmutable
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        try {
+            return new \DateTimeImmutable($value);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    public static function applyListMeta(array $payload, array $params = []): array
+    {
+        $data = $payload['data'] ?? [];
+        $count = is_array($data) ? count($data) : 0;
+
+        $payload['meta'] = array_merge([
+            'page' => isset($params['page']) ? (int) $params['page'] : 1,
+            'per_page' => isset($params['per_page']) ? (int) $params['per_page'] : ($count > 0 ? $count : null),
+            'count' => $count,
+        ], $payload['meta'] ?? []);
+
+        return $payload;
+    }
+
+    private static function safeFloatval(string $value): float
+    {
+        if (preg_match('/-?\d+(?:\.\d+)?/', $value, $matches) === 1) {
+            return (float) $matches[0];
+        }
+
+        return (float) $value;
+    }
+
+    private static function isAssoc(array $array): bool
+    {
+        return $array !== [] && array_keys($array) !== range(0, count($array) - 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add Lotus API configuration controls to the general settings page and persist the new options via system settings
- introduce an application-level LotusPartnerApi service that wraps the SDK client and normalizes order submission metadata
- trigger Lotus order creation from panel and API product purchases while updating local order records and exposing delivered content on the customer order list

## Testing
- php -l admin/settings-general.php
- php -l api/v1/orders.php
- php -l orders.php
- php -l products.php
- php -l app/Services/LotusPartnerApi.php

------
https://chatgpt.com/codex/tasks/task_b_68dfc0c294808321aaf7c98c9246a2c0