### PR TITLE
Add blog management and frontend pages

### DIFF
--- a/admin/blog-categories.php
+++ b/admin/blog-categories.php
@@ -1,0 +1,296 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+use App\Auth;
+use App\AuditLog;
+use App\Blog\BlogRepository;
+use App\Database;
+use App\Helpers;
+
+Auth::requireRoles(array('super_admin', 'admin', 'content'));
+
+$pdo = Database::connection();
+$currentUser = $_SESSION['user'];
+$errors = array();
+$success = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = isset($_POST['action']) ? $_POST['action'] : '';
+    $token = isset($_POST['csrf_token']) ? $_POST['csrf_token'] : '';
+
+    if (!Helpers::verifyCsrf($token)) {
+        $errors[] = 'Geçersiz güvenlik anahtarı. Lütfen sayfayı yenileyerek tekrar deneyin.';
+    } else {
+        if ($action === 'create_category') {
+            $name = isset($_POST['name']) ? trim($_POST['name']) : '';
+            $description = isset($_POST['description']) ? trim($_POST['description']) : '';
+            $metaTitle = isset($_POST['meta_title']) ? trim($_POST['meta_title']) : '';
+            $metaDescription = isset($_POST['meta_description']) ? trim($_POST['meta_description']) : '';
+
+            if ($name === '') {
+                $errors[] = 'Kategori adı zorunludur.';
+            }
+
+            if (!$errors) {
+                $slug = BlogRepository::uniqueCategorySlug($name);
+
+                $stmt = $pdo->prepare('INSERT INTO blog_categories (name, slug, description, meta_title, meta_description, created_at) VALUES (:name, :slug, :description, :meta_title, :meta_description, NOW())');
+                $stmt->execute(array(
+                    ':name' => $name,
+                    ':slug' => $slug,
+                    ':description' => $description !== '' ? $description : null,
+                    ':meta_title' => $metaTitle !== '' ? $metaTitle : null,
+                    ':meta_description' => $metaDescription !== '' ? $metaDescription : null,
+                ));
+
+                $success = 'Kategori oluşturuldu.';
+
+                AuditLog::record(
+                    $currentUser['id'],
+                    'blog_category.create',
+                    'blog_category',
+                    (int)$pdo->lastInsertId(),
+                    sprintf('Blog kategorisi oluşturuldu: %s', $name)
+                );
+            }
+        } elseif ($action === 'update_category') {
+            $categoryId = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+            $name = isset($_POST['name']) ? trim($_POST['name']) : '';
+            $slugInput = isset($_POST['slug']) ? trim($_POST['slug']) : '';
+            $description = isset($_POST['description']) ? trim($_POST['description']) : '';
+            $metaTitle = isset($_POST['meta_title']) ? trim($_POST['meta_title']) : '';
+            $metaDescription = isset($_POST['meta_description']) ? trim($_POST['meta_description']) : '';
+
+            if ($categoryId <= 0) {
+                $errors[] = 'Geçersiz kategori seçimi.';
+            }
+
+            if ($name === '') {
+                $errors[] = 'Kategori adı zorunludur.';
+            }
+
+            $category = $categoryId > 0 ? BlogRepository::findCategoryById($categoryId) : null;
+            if (!$category) {
+                $errors[] = 'Kategori bulunamadı.';
+            }
+
+            if (!$errors) {
+                $slug = $slugInput !== '' ? Helpers::slugify($slugInput) : BlogRepository::uniqueCategorySlug($name, $categoryId);
+                if ($slug === '') {
+                    $slug = BlogRepository::uniqueCategorySlug($name, $categoryId);
+                }
+
+                if ($slug !== $category['slug']) {
+                    $slug = BlogRepository::uniqueCategorySlug($slug, $categoryId);
+                }
+
+                $stmt = $pdo->prepare('UPDATE blog_categories SET name = :name, slug = :slug, description = :description, meta_title = :meta_title, meta_description = :meta_description, updated_at = NOW() WHERE id = :id');
+                $stmt->execute(array(
+                    ':id' => $categoryId,
+                    ':name' => $name,
+                    ':slug' => $slug,
+                    ':description' => $description !== '' ? $description : null,
+                    ':meta_title' => $metaTitle !== '' ? $metaTitle : null,
+                    ':meta_description' => $metaDescription !== '' ? $metaDescription : null,
+                ));
+
+                $success = 'Kategori güncellendi.';
+
+                AuditLog::record(
+                    $currentUser['id'],
+                    'blog_category.update',
+                    'blog_category',
+                    $categoryId,
+                    sprintf('Blog kategorisi güncellendi: %s', $name)
+                );
+            }
+        } elseif ($action === 'delete_category') {
+            $categoryId = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+
+            if ($categoryId <= 0) {
+                $errors[] = 'Geçersiz kategori seçimi.';
+            } else {
+                $stmt = $pdo->prepare('SELECT COUNT(*) FROM blog_posts WHERE category_id = :id');
+                $stmt->execute(array(':id' => $categoryId));
+                $postCount = (int)$stmt->fetchColumn();
+
+                if ($postCount > 0) {
+                    $errors[] = 'Bu kategoriye bağlı yazılar bulunduğu için silinemez.';
+                }
+            }
+
+            if (!$errors) {
+                $stmt = $pdo->prepare('DELETE FROM blog_categories WHERE id = :id');
+                $stmt->execute(array(':id' => $categoryId));
+
+                $success = 'Kategori silindi.';
+
+                AuditLog::record(
+                    $currentUser['id'],
+                    'blog_category.delete',
+                    'blog_category',
+                    $categoryId,
+                    sprintf('Blog kategorisi silindi: #%d', $categoryId)
+                );
+            }
+        }
+    }
+}
+
+$categories = $pdo->query('SELECT c.*, COUNT(p.id) AS post_count FROM blog_categories AS c LEFT JOIN blog_posts AS p ON p.category_id = c.id GROUP BY c.id ORDER BY c.created_at DESC')->fetchAll();
+
+$pageTitle = 'Blog Kategorileri';
+include __DIR__ . '/../templates/header.php';
+?>
+<div class="container-fluid">
+    <div class="row mb-4">
+        <div class="col-lg-8">
+            <h1 class="h3 mb-0">Blog Kategorileri</h1>
+            <p class="text-muted">Blog yazılarını düzenlemek için kategorileri yönetin.</p>
+        </div>
+        <div class="col-lg-4 text-lg-end">
+            <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createCategory"><i class="bi bi-plus-lg me-2"></i>Yeni Kategori</button>
+        </div>
+    </div>
+
+    <?php if ($errors): ?>
+        <div class="alert alert-danger">
+            <ul class="mb-0">
+                <?php foreach ($errors as $error): ?>
+                    <li><?= Helpers::sanitize($error) ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($success): ?>
+        <div class="alert alert-success"><?= Helpers::sanitize($success) ?></div>
+    <?php endif; ?>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0 align-middle">
+                    <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Başlık</th>
+                        <th>Slug</th>
+                        <th>Yazı Sayısı</th>
+                        <th>Oluşturma</th>
+                        <th class="text-end">İşlemler</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <?php if (!$categories): ?>
+                        <tr>
+                            <td colspan="6" class="text-center text-muted py-4">Henüz kategori oluşturulmamış.</td>
+                        </tr>
+                    <?php else: ?>
+                        <?php foreach ($categories as $category): ?>
+                            <tr>
+                                <td>#<?= (int)$category['id'] ?></td>
+                                <td><?= Helpers::sanitize($category['name']) ?></td>
+                                <td><span class="badge bg-light text-dark"><?= Helpers::sanitize($category['slug'] ?? '') ?></span></td>
+                                <td><?= (int)$category['post_count'] ?></td>
+                                <td><?= Helpers::sanitize(date('d.m.Y H:i', strtotime($category['created_at']))) ?></td>
+                                <td class="text-end">
+                                    <button class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editCategory<?= (int)$category['id'] ?>">Düzenle</button>
+                                    <form method="post" class="d-inline" onsubmit="return confirm('Kategoriyi silmek istediğinize emin misiniz?');">
+                                        <input type="hidden" name="action" value="delete_category">
+                                        <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                                        <input type="hidden" name="id" value="<?= (int)$category['id'] ?>">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">Sil</button>
+                                    </form>
+                                </td>
+                            </tr>
+
+                            <div class="modal fade" id="editCategory<?= (int)$category['id'] ?>" tabindex="-1" aria-hidden="true">
+                                <div class="modal-dialog modal-lg">
+                                    <div class="modal-content">
+                                        <form method="post">
+                                            <div class="modal-header">
+                                                <h5 class="modal-title">Kategoriyi Düzenle</h5>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                            </div>
+                                            <div class="modal-body">
+                                                <input type="hidden" name="action" value="update_category">
+                                                <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                                                <input type="hidden" name="id" value="<?= (int)$category['id'] ?>">
+                                                <div class="mb-3">
+                                                    <label class="form-label">Kategori Adı</label>
+                                                    <input type="text" name="name" class="form-control" value="<?= Helpers::sanitize($category['name']) ?>" required>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <label class="form-label">URL Slug</label>
+                                                    <input type="text" name="slug" class="form-control" value="<?= Helpers::sanitize($category['slug'] ?? '') ?>">
+                                                    <div class="form-text">Boş bırakırsanız otomatik oluşturulur.</div>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <label class="form-label">Açıklama</label>
+                                                    <textarea name="description" class="form-control" rows="3"><?= Helpers::sanitize($category['description'] ?? '') ?></textarea>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <label class="form-label">Meta Başlık</label>
+                                                    <input type="text" name="meta_title" class="form-control" value="<?= Helpers::sanitize($category['meta_title'] ?? '') ?>">
+                                                </div>
+                                                <div class="mb-3">
+                                                    <label class="form-label">Meta Açıklama</label>
+                                                    <textarea name="meta_description" class="form-control" rows="2"><?= Helpers::sanitize($category['meta_description'] ?? '') ?></textarea>
+                                                </div>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+                                                <button type="submit" class="btn btn-primary">Kaydet</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="createCategory" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <form method="post">
+                <div class="modal-header">
+                    <h5 class="modal-title">Yeni Blog Kategorisi</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="action" value="create_category">
+                    <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                    <div class="mb-3">
+                        <label class="form-label">Kategori Adı</label>
+                        <input type="text" name="name" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Açıklama</label>
+                        <textarea name="description" class="form-control" rows="3"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Meta Başlık</label>
+                        <input type="text" name="meta_title" class="form-control">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Meta Açıklama</label>
+                        <textarea name="meta_description" class="form-control" rows="2"></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
+                    <button type="submit" class="btn btn-primary">Oluştur</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<?php include __DIR__ . '/../templates/footer.php';

--- a/admin/blog-posts.php
+++ b/admin/blog-posts.php
@@ -1,0 +1,467 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+use App\Auth;
+use App\AuditLog;
+use App\Blog\BlogRepository;
+use App\Database;
+use App\Helpers;
+
+Auth::requireRoles(array('super_admin', 'admin', 'content'));
+
+$pdo = Database::connection();
+$currentUser = $_SESSION['user'];
+$errors = array();
+$success = '';
+$categories = $pdo->query('SELECT id, name FROM blog_categories ORDER BY name ASC')->fetchAll();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = isset($_POST['action']) ? $_POST['action'] : '';
+    $token = isset($_POST['csrf_token']) ? $_POST['csrf_token'] : '';
+
+    if (!Helpers::verifyCsrf($token)) {
+        $errors[] = 'Geçersiz güvenlik anahtarı. Lütfen sayfayı yenileyerek tekrar deneyin.';
+    } else {
+        if ($action === 'create_post') {
+            $title = isset($_POST['title']) ? trim($_POST['title']) : '';
+            $categoryId = isset($_POST['category_id']) && $_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null;
+            $excerpt = isset($_POST['excerpt']) ? trim($_POST['excerpt']) : '';
+            $content = isset($_POST['content']) ? trim($_POST['content']) : '';
+            $imageUrl = isset($_POST['image_url']) ? trim($_POST['image_url']) : '';
+            $status = isset($_POST['status']) && $_POST['status'] === 'published' ? 'published' : 'draft';
+            $publishedAtInput = isset($_POST['published_at']) ? trim($_POST['published_at']) : '';
+            $metaTitle = isset($_POST['meta_title']) ? trim($_POST['meta_title']) : '';
+            $metaDescription = isset($_POST['meta_description']) ? trim($_POST['meta_description']) : '';
+            $authorName = isset($_POST['author_name']) && $_POST['author_name'] !== '' ? trim($_POST['author_name']) : $currentUser['name'];
+
+            if ($title === '') {
+                $errors[] = 'Başlık alanı zorunludur.';
+            }
+
+            if ($content === '') {
+                $errors[] = 'İçerik alanı boş bırakılamaz.';
+            }
+
+            if ($categoryId) {
+                $categoryExists = $pdo->prepare('SELECT id FROM blog_categories WHERE id = :id LIMIT 1');
+                $categoryExists->execute(array(':id' => $categoryId));
+                if (!$categoryExists->fetchColumn()) {
+                    $errors[] = 'Seçilen kategori bulunamadı.';
+                }
+            }
+
+            if (!$errors) {
+                $slug = BlogRepository::uniquePostSlug($title);
+                $publishedAt = null;
+
+                if ($status === 'published') {
+                    if ($publishedAtInput !== '') {
+                        $timestamp = strtotime($publishedAtInput);
+                        if ($timestamp) {
+                            $publishedAt = date('Y-m-d H:i:s', $timestamp);
+                        }
+                    }
+
+                    if ($publishedAt === null) {
+                        $publishedAt = date('Y-m-d H:i:s');
+                    }
+                }
+
+                if ($excerpt === '') {
+                    $excerpt = Helpers::truncate(strip_tags($content), 180);
+                }
+
+                $stmt = $pdo->prepare('INSERT INTO blog_posts (category_id, title, slug, excerpt, content, image_url, author_name, status, published_at, meta_title, meta_description, created_at) VALUES (:category_id, :title, :slug, :excerpt, :content, :image_url, :author_name, :status, :published_at, :meta_title, :meta_description, NOW())');
+                $stmt->execute(array(
+                    ':category_id' => $categoryId,
+                    ':title' => $title,
+                    ':slug' => $slug,
+                    ':excerpt' => $excerpt !== '' ? $excerpt : null,
+                    ':content' => $content,
+                    ':image_url' => $imageUrl !== '' ? $imageUrl : null,
+                    ':author_name' => $authorName !== '' ? $authorName : null,
+                    ':status' => $status,
+                    ':published_at' => $publishedAt,
+                    ':meta_title' => $metaTitle !== '' ? $metaTitle : null,
+                    ':meta_description' => $metaDescription !== '' ? $metaDescription : null,
+                ));
+
+                $success = 'Blog yazısı oluşturuldu.';
+
+                AuditLog::record(
+                    $currentUser['id'],
+                    'blog_post.create',
+                    'blog_post',
+                    (int)$pdo->lastInsertId(),
+                    sprintf('Blog yazısı oluşturuldu: %s', $title)
+                );
+            }
+        } elseif ($action === 'update_post') {
+            $postId = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+            $title = isset($_POST['title']) ? trim($_POST['title']) : '';
+            $categoryId = isset($_POST['category_id']) && $_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null;
+            $excerpt = isset($_POST['excerpt']) ? trim($_POST['excerpt']) : '';
+            $content = isset($_POST['content']) ? trim($_POST['content']) : '';
+            $imageUrl = isset($_POST['image_url']) ? trim($_POST['image_url']) : '';
+            $status = isset($_POST['status']) && $_POST['status'] === 'published' ? 'published' : 'draft';
+            $publishedAtInput = isset($_POST['published_at']) ? trim($_POST['published_at']) : '';
+            $metaTitle = isset($_POST['meta_title']) ? trim($_POST['meta_title']) : '';
+            $metaDescription = isset($_POST['meta_description']) ? trim($_POST['meta_description']) : '';
+            $authorName = isset($_POST['author_name']) ? trim($_POST['author_name']) : '';
+            $slugInput = isset($_POST['slug']) ? trim($_POST['slug']) : '';
+
+            if ($postId <= 0) {
+                $errors[] = 'Geçersiz yazı seçimi.';
+            }
+
+            if ($title === '') {
+                $errors[] = 'Başlık alanı zorunludur.';
+            }
+
+            if ($content === '') {
+                $errors[] = 'İçerik alanı boş bırakılamaz.';
+            }
+
+            $postStmt = $pdo->prepare('SELECT * FROM blog_posts WHERE id = :id LIMIT 1');
+            $postStmt->execute(array(':id' => $postId));
+            $postRow = $postStmt->fetch();
+            if (!$postRow) {
+                $errors[] = 'Blog yazısı bulunamadı.';
+            }
+
+            if ($categoryId) {
+                $categoryExists = $pdo->prepare('SELECT id FROM blog_categories WHERE id = :id LIMIT 1');
+                $categoryExists->execute(array(':id' => $categoryId));
+                if (!$categoryExists->fetchColumn()) {
+                    $errors[] = 'Seçilen kategori bulunamadı.';
+                }
+            }
+
+            if (!$errors) {
+                $slug = $slugInput !== '' ? Helpers::slugify($slugInput) : BlogRepository::uniquePostSlug($title, $postId);
+                if ($slug === '') {
+                    $slug = BlogRepository::uniquePostSlug($title, $postId);
+                }
+
+                if ($slug !== $postRow['slug']) {
+                    $slug = BlogRepository::uniquePostSlug($slug, $postId);
+                }
+
+                $publishedAt = null;
+                if ($status === 'published') {
+                    if ($publishedAtInput !== '') {
+                        $timestamp = strtotime($publishedAtInput);
+                        if ($timestamp) {
+                            $publishedAt = date('Y-m-d H:i:s', $timestamp);
+                        }
+                    }
+
+                    if ($publishedAt === null) {
+                        $publishedAt = $postRow['published_at'] ? $postRow['published_at'] : date('Y-m-d H:i:s');
+                    }
+                }
+
+                if ($excerpt === '') {
+                    $excerpt = Helpers::truncate(strip_tags($content), 180);
+                }
+
+                $stmt = $pdo->prepare('UPDATE blog_posts SET category_id = :category_id, title = :title, slug = :slug, excerpt = :excerpt, content = :content, image_url = :image_url, author_name = :author_name, status = :status, published_at = :published_at, meta_title = :meta_title, meta_description = :meta_description, updated_at = NOW() WHERE id = :id');
+                $stmt->execute(array(
+                    ':id' => $postId,
+                    ':category_id' => $categoryId,
+                    ':title' => $title,
+                    ':slug' => $slug,
+                    ':excerpt' => $excerpt !== '' ? $excerpt : null,
+                    ':content' => $content,
+                    ':image_url' => $imageUrl !== '' ? $imageUrl : null,
+                    ':author_name' => $authorName !== '' ? $authorName : null,
+                    ':status' => $status,
+                    ':published_at' => $publishedAt,
+                    ':meta_title' => $metaTitle !== '' ? $metaTitle : null,
+                    ':meta_description' => $metaDescription !== '' ? $metaDescription : null,
+                ));
+
+                $success = 'Blog yazısı güncellendi.';
+
+                AuditLog::record(
+                    $currentUser['id'],
+                    'blog_post.update',
+                    'blog_post',
+                    $postId,
+                    sprintf('Blog yazısı güncellendi: %s', $title)
+                );
+            }
+        } elseif ($action === 'delete_post') {
+            $postId = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+
+            if ($postId <= 0) {
+                $errors[] = 'Geçersiz yazı seçimi.';
+            }
+
+            if (!$errors) {
+                $stmt = $pdo->prepare('DELETE FROM blog_posts WHERE id = :id');
+                $stmt->execute(array(':id' => $postId));
+
+                $success = 'Blog yazısı silindi.';
+
+                AuditLog::record(
+                    $currentUser['id'],
+                    'blog_post.delete',
+                    'blog_post',
+                    $postId,
+                    sprintf('Blog yazısı silindi: #%d', $postId)
+                );
+            }
+        }
+    }
+}
+
+$postsStmt = $pdo->query('SELECT p.*, c.name AS category_name FROM blog_posts AS p LEFT JOIN blog_categories AS c ON c.id = p.category_id ORDER BY p.created_at DESC');
+$posts = $postsStmt ? $postsStmt->fetchAll() : array();
+
+$pageTitle = 'Blog Yazıları';
+include __DIR__ . '/../templates/header.php';
+?>
+<div class="container-fluid">
+    <div class="row mb-4">
+        <div class="col-lg-8">
+            <h1 class="h3 mb-0">Blog Yazıları</h1>
+            <p class="text-muted">Sitenizde yayınlanan blog yazılarını buradan oluşturup yönetebilirsiniz.</p>
+        </div>
+        <div class="col-lg-4 text-lg-end">
+            <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createPost"><i class="bi bi-plus-lg me-2"></i>Yeni Yazı</button>
+        </div>
+    </div>
+
+    <?php if ($errors): ?>
+        <div class="alert alert-danger">
+            <ul class="mb-0">
+                <?php foreach ($errors as $error): ?>
+                    <li><?= Helpers::sanitize($error) ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <?php if ($success): ?>
+        <div class="alert alert-success"><?= Helpers::sanitize($success) ?></div>
+    <?php endif; ?>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0 align-middle">
+                    <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Başlık</th>
+                        <th>Kategori</th>
+                        <th>Durum</th>
+                        <th>Yayın</th>
+                        <th class="text-end">İşlemler</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <?php if (!$posts): ?>
+                        <tr>
+                            <td colspan="6" class="text-center text-muted py-4">Henüz blog yazısı oluşturulmamış.</td>
+                        </tr>
+                    <?php else: ?>
+                        <?php foreach ($posts as $post): ?>
+                            <tr>
+                                <td>#<?= (int)$post['id'] ?></td>
+                                <td>
+                                    <div class="fw-semibold"><?= Helpers::sanitize($post['title']) ?></div>
+                                    <div class="text-muted small">/blog/<?= Helpers::sanitize($post['slug'] ?? '') ?></div>
+                                </td>
+                                <td>
+                                    <?php if (!empty($post['category_name'])): ?>
+                                        <?= Helpers::sanitize($post['category_name']) ?>
+                                    <?php else: ?>
+                                        <span class="text-muted">(Genel)</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td>
+                                    <?php if ($post['status'] === 'published'): ?>
+                                        <span class="badge bg-success">Yayında</span>
+                                    <?php else: ?>
+                                        <span class="badge bg-secondary">Taslak</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?= $post['published_at'] ? Helpers::sanitize(date('d.m.Y H:i', strtotime($post['published_at']))) : '—' ?></td>
+                                <td class="text-end">
+                                    <button class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editPost<?= (int)$post['id'] ?>">Düzenle</button>
+                                    <form method="post" class="d-inline" onsubmit="return confirm('Blog yazısını silmek istediğinize emin misiniz?');">
+                                        <input type="hidden" name="action" value="delete_post">
+                                        <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                                        <input type="hidden" name="id" value="<?= (int)$post['id'] ?>">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">Sil</button>
+                                    </form>
+                                </td>
+                            </tr>
+
+                            <div class="modal fade" id="editPost<?= (int)$post['id'] ?>" tabindex="-1" aria-hidden="true">
+                                <div class="modal-dialog modal-xl">
+                                    <div class="modal-content">
+                                        <form method="post">
+                                            <div class="modal-header">
+                                                <h5 class="modal-title">Blog Yazısını Düzenle</h5>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                            </div>
+                                            <div class="modal-body">
+                                                <input type="hidden" name="action" value="update_post">
+                                                <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                                                <input type="hidden" name="id" value="<?= (int)$post['id'] ?>">
+                                                <div class="row g-3">
+                                                    <div class="col-lg-8">
+                                                        <div class="mb-3">
+                                                            <label class="form-label">Başlık</label>
+                                                            <input type="text" name="title" class="form-control" value="<?= Helpers::sanitize($post['title']) ?>" required>
+                                                        </div>
+                                                        <div class="mb-3">
+                                                            <label class="form-label">Kısa Açıklama</label>
+                                                            <textarea name="excerpt" class="form-control" rows="2"><?= Helpers::sanitize($post['excerpt'] ?? '') ?></textarea>
+                                                        </div>
+                                                        <div class="mb-3">
+                                                            <label class="form-label">İçerik</label>
+                                                            <textarea name="content" class="form-control" rows="10" required><?= Helpers::sanitize($post['content'] ?? '') ?></textarea>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-lg-4">
+                                                        <div class="mb-3">
+                                                            <label class="form-label">Kategori</label>
+                                                            <select name="category_id" class="form-select">
+                                                                <option value="">(Genel)</option>
+                                                                <?php foreach ($categories as $category): ?>
+                                                                    <option value="<?= (int)$category['id'] ?>" <?= (int)$post['category_id'] === (int)$category['id'] ? 'selected' : '' ?>><?= Helpers::sanitize($category['name']) ?></option>
+                                                                <?php endforeach; ?>
+                                                            </select>
+                                                        </div>
+                                                        <div class="mb-3">
+                                                            <label class="form-label">Durum</label>
+                                                            <select name="status" class="form-select">
+                                                                <option value="draft" <?= $post['status'] === 'draft' ? 'selected' : '' ?>>Taslak</option>
+                                                                <option value="published" <?= $post['status'] === 'published' ? 'selected' : '' ?>>Yayında</option>
+                                                            </select>
+                                                        </div>
+                                                        <div class="mb-3">
+                                                            <label class="form-label">Yayın Tarihi</label>
+                                                            <input type="datetime-local" name="published_at" class="form-control" value="<?= $post['published_at'] ? Helpers::sanitize(date('Y-m-d\TH:i', strtotime($post['published_at']))) : '' ?>">
+                                                        </div>
+                                                        <div class="mb-3">
+                                                            <label class="form-label">Kapak Görseli URL</label>
+                                                            <input type="url" name="image_url" class="form-control" value="<?= Helpers::sanitize($post['image_url'] ?? '') ?>">
+                                                        </div>
+                                                        <div class="mb-3">
+                                                            <label class="form-label">Yazar Adı</label>
+                                                            <input type="text" name="author_name" class="form-control" value="<?= Helpers::sanitize($post['author_name'] ?? '') ?>">
+                                                        </div>
+                                                        <div class="mb-3">
+                                                            <label class="form-label">Slug</label>
+                                                            <input type="text" name="slug" class="form-control" value="<?= Helpers::sanitize($post['slug'] ?? '') ?>">
+                                                            <div class="form-text">Boş bırakırsanız otomatik oluşturulur.</div>
+                                                        </div>
+                                                        <div class="mb-3">
+                                                            <label class="form-label">Meta Başlık</label>
+                                                            <input type="text" name="meta_title" class="form-control" value="<?= Helpers::sanitize($post['meta_title'] ?? '') ?>">
+                                                        </div>
+                                                        <div class="mb-3">
+                                                            <label class="form-label">Meta Açıklama</label>
+                                                            <textarea name="meta_description" class="form-control" rows="2"><?= Helpers::sanitize($post['meta_description'] ?? '') ?></textarea>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+                                                <button type="submit" class="btn btn-primary">Kaydet</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="createPost" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <form method="post">
+                <div class="modal-header">
+                    <h5 class="modal-title">Yeni Blog Yazısı</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" name="action" value="create_post">
+                    <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                    <div class="row g-3">
+                        <div class="col-lg-8">
+                            <div class="mb-3">
+                                <label class="form-label">Başlık</label>
+                                <input type="text" name="title" class="form-control" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Kısa Açıklama</label>
+                                <textarea name="excerpt" class="form-control" rows="2"></textarea>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">İçerik</label>
+                                <textarea name="content" class="form-control" rows="10" required></textarea>
+                            </div>
+                        </div>
+                        <div class="col-lg-4">
+                            <div class="mb-3">
+                                <label class="form-label">Kategori</label>
+                                <select name="category_id" class="form-select">
+                                    <option value="">(Genel)</option>
+                                    <?php foreach ($categories as $category): ?>
+                                        <option value="<?= (int)$category['id'] ?>"><?= Helpers::sanitize($category['name']) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Durum</label>
+                                <select name="status" class="form-select">
+                                    <option value="draft">Taslak</option>
+                                    <option value="published">Yayında</option>
+                                </select>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Yayın Tarihi</label>
+                                <input type="datetime-local" name="published_at" class="form-control">
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Kapak Görseli URL</label>
+                                <input type="url" name="image_url" class="form-control">
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Yazar Adı</label>
+                                <input type="text" name="author_name" class="form-control" value="<?= Helpers::sanitize($currentUser['name']) ?>">
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Meta Başlık</label>
+                                <input type="text" name="meta_title" class="form-control">
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Meta Açıklama</label>
+                                <textarea name="meta_description" class="form-control" rows="2"></textarea>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
+                    <button type="submit" class="btn btn-primary">Oluştur</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<?php include __DIR__ . '/../templates/footer.php';

--- a/app/Blog/BlogRepository.php
+++ b/app/Blog/BlogRepository.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace App\Blog;
+
+use App\Database;
+use App\Helpers;
+use PDO;
+
+class BlogRepository
+{
+    /**
+     * @param bool $onlyPublished
+     * @return array<int,array<string,mixed>>
+     */
+    public static function categories($onlyPublished = true)
+    {
+        $pdo = Database::connection();
+
+        $sql = "SELECT c.id, c.name, c.slug, c.description, c.meta_title, c.meta_description, c.created_at, c.updated_at,"
+            . " COUNT(p.id) AS post_count"
+            . " FROM blog_categories AS c"
+            . " LEFT JOIN blog_posts AS p ON p.category_id = c.id";
+
+        if ($onlyPublished) {
+            $sql .= " AND p.status = 'published'";
+        }
+
+        $sql .= " GROUP BY c.id ORDER BY c.name ASC";
+
+        $stmt = $pdo->query($sql);
+        if (!$stmt) {
+            return array();
+        }
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: array();
+    }
+
+    /**
+     * @param string $slug
+     * @return array<string,mixed>|null
+     */
+    public static function findCategoryBySlug($slug)
+    {
+        if ($slug === '') {
+            return null;
+        }
+
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT * FROM blog_categories WHERE slug = :slug LIMIT 1');
+        $stmt->execute(array(':slug' => $slug));
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ?: null;
+    }
+
+    /**
+     * @param int $id
+     * @return array<string,mixed>|null
+     */
+    public static function findCategoryById($id)
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT * FROM blog_categories WHERE id = :id LIMIT 1');
+        $stmt->execute(array(':id' => $id));
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ?: null;
+    }
+
+    /**
+     * @param int $limit
+     * @return array<int,array<string,mixed>>
+     */
+    public static function latestPosts($limit = 5)
+    {
+        $limit = max(1, (int)$limit);
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare(
+            "SELECT p.*, c.name AS category_name, c.slug AS category_slug"
+            . " FROM blog_posts AS p"
+            . " LEFT JOIN blog_categories AS c ON c.id = p.category_id"
+            . " WHERE p.status = 'published'"
+            . " ORDER BY COALESCE(p.published_at, p.created_at) DESC"
+            . " LIMIT :limit"
+        );
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: array();
+    }
+
+    /**
+     * @param int $limit
+     * @param int $offset
+     * @param int|null $categoryId
+     * @param bool $publishedOnly
+     * @return array<int,array<string,mixed>>
+     */
+    public static function listPosts($limit, $offset = 0, $categoryId = null, $publishedOnly = true)
+    {
+        $limit = max(1, (int)$limit);
+        $offset = max(0, (int)$offset);
+
+        $pdo = Database::connection();
+
+        $sql = "SELECT p.*, c.name AS category_name, c.slug AS category_slug"
+            . " FROM blog_posts AS p"
+            . " LEFT JOIN blog_categories AS c ON c.id = p.category_id"
+            . " WHERE 1=1";
+
+        $params = array();
+
+        if ($publishedOnly) {
+            $sql .= " AND p.status = 'published'";
+        }
+
+        if ($categoryId) {
+            $sql .= " AND p.category_id = :category";
+            $params[':category'] = (int)$categoryId;
+        }
+
+        $sql .= " ORDER BY COALESCE(p.published_at, p.created_at) DESC"
+            . " LIMIT :limit OFFSET :offset";
+
+        $stmt = $pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: array();
+    }
+
+    /**
+     * @param int|null $categoryId
+     * @param bool $publishedOnly
+     * @return int
+     */
+    public static function countPosts($categoryId = null, $publishedOnly = true)
+    {
+        $pdo = Database::connection();
+
+        $sql = "SELECT COUNT(*) FROM blog_posts WHERE 1=1";
+        $params = array();
+
+        if ($publishedOnly) {
+            $sql .= " AND status = 'published'";
+        }
+
+        if ($categoryId) {
+            $sql .= " AND category_id = :category";
+            $params[':category'] = (int)$categoryId;
+        }
+
+        $stmt = $pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value, PDO::PARAM_INT);
+        }
+        $stmt->execute();
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * @param string $slug
+     * @param bool $publishedOnly
+     * @return array<string,mixed>|null
+     */
+    public static function findPostBySlug($slug, $publishedOnly = true)
+    {
+        if ($slug === '') {
+            return null;
+        }
+
+        $pdo = Database::connection();
+        $sql = "SELECT p.*, c.name AS category_name, c.slug AS category_slug"
+            . " FROM blog_posts AS p"
+            . " LEFT JOIN blog_categories AS c ON c.id = p.category_id"
+            . " WHERE p.slug = :slug";
+
+        if ($publishedOnly) {
+            $sql .= " AND p.status = 'published'";
+        }
+
+        $sql .= " LIMIT 1";
+
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(array(':slug' => $slug));
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ?: null;
+    }
+
+    /**
+     * @param int $postId
+     * @param int|null $categoryId
+     * @param int $limit
+     * @return array<int,array<string,mixed>>
+     */
+    public static function relatedPosts($postId, $categoryId = null, $limit = 3)
+    {
+        $pdo = Database::connection();
+
+        $sql = "SELECT p.*, c.name AS category_name, c.slug AS category_slug"
+            . " FROM blog_posts AS p"
+            . " LEFT JOIN blog_categories AS c ON c.id = p.category_id"
+            . " WHERE p.status = 'published' AND p.id != :id";
+
+        $params = array(':id' => (int)$postId);
+
+        if ($categoryId) {
+            $sql .= " AND p.category_id = :category";
+            $params[':category'] = (int)$categoryId;
+        }
+
+        $sql .= " ORDER BY COALESCE(p.published_at, p.created_at) DESC"
+            . " LIMIT :limit";
+
+        $stmt = $pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':limit', max(1, (int)$limit), PDO::PARAM_INT);
+        $stmt->execute();
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: array();
+    }
+
+    /**
+     * @param string $title
+     * @param int|null $ignoreId
+     * @return string
+     */
+    public static function uniquePostSlug($title, $ignoreId = null)
+    {
+        $slug = Helpers::slugify($title);
+        if ($slug === '') {
+            $slug = 'yazi';
+        }
+
+        $pdo = Database::connection();
+        $base = $slug;
+        $suffix = 2;
+
+        while (true) {
+            $query = 'SELECT id FROM blog_posts WHERE slug = :slug';
+            $params = array(':slug' => $slug);
+            if ($ignoreId) {
+                $query .= ' AND id != :ignore';
+                $params[':ignore'] = (int)$ignoreId;
+            }
+
+            $stmt = $pdo->prepare($query . ' LIMIT 1');
+            $stmt->execute($params);
+            if (!$stmt->fetch(PDO::FETCH_ASSOC)) {
+                return $slug;
+            }
+
+            $slug = $base . '-' . $suffix;
+            $suffix++;
+        }
+    }
+
+    /**
+     * @param string $name
+     * @param int|null $ignoreId
+     * @return string
+     */
+    public static function uniqueCategorySlug($name, $ignoreId = null)
+    {
+        $slug = Helpers::slugify($name);
+        if ($slug === '') {
+            $slug = 'kategori';
+        }
+
+        $pdo = Database::connection();
+        $base = $slug;
+        $suffix = 2;
+
+        while (true) {
+            $query = 'SELECT id FROM blog_categories WHERE slug = :slug';
+            $params = array(':slug' => $slug);
+            if ($ignoreId) {
+                $query .= ' AND id != :ignore';
+                $params[':ignore'] = (int)$ignoreId;
+            }
+
+            $stmt = $pdo->prepare($query . ' LIMIT 1');
+            $stmt->execute($params);
+            if (!$stmt->fetch(PDO::FETCH_ASSOC)) {
+                return $slug;
+            }
+
+            $slug = $base . '-' . $suffix;
+            $suffix++;
+        }
+    }
+}

--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -131,6 +131,52 @@ class Helpers
     }
 
     /**
+     * @param string $value
+     * @return string
+     */
+    public static function slugify($value)
+    {
+        $value = trim((string)$value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        if (function_exists('mb_strtolower')) {
+            $value = mb_strtolower($value, 'UTF-8');
+        } else {
+            $value = strtolower($value);
+        }
+
+        $replacements = array(
+            'ı' => 'i',
+            'ğ' => 'g',
+            'ü' => 'u',
+            'ş' => 's',
+            'ö' => 'o',
+            'ç' => 'c',
+        );
+        $value = strtr($value, $replacements);
+
+        if (function_exists('iconv')) {
+            $transliterated = @iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $value);
+            if ($transliterated !== false) {
+                $value = $transliterated;
+            }
+        }
+
+        $value = preg_replace('/[^a-z0-9]+/i', '-', $value);
+        if ($value === null) {
+            $value = '';
+        }
+
+        $value = trim($value, '-');
+        $value = preg_replace('/-+/', '-', $value);
+
+        return $value !== null ? $value : '';
+    }
+
+    /**
      * Legacy stub kept for backwards compatibility.
      *
      * @param string $path

--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -1,0 +1,162 @@
+:root {
+    --public-bg: #0e1015;
+    --public-accent: #0066ff;
+    --public-text: #f4f6fb;
+    --public-muted: #8a8f9d;
+    --public-card-bg: #151922;
+}
+
+body.public-app {
+    background-color: var(--public-bg);
+    color: var(--public-text);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.public-main {
+    flex: 1 0 auto;
+}
+
+.public-card {
+    background-color: var(--public-card-bg);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 18px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    overflow: hidden;
+}
+
+.public-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.45);
+}
+
+.public-card img {
+    object-fit: cover;
+}
+
+.public-card-title {
+    color: var(--public-text);
+}
+
+.public-card-meta {
+    color: var(--public-muted);
+    font-size: 0.875rem;
+}
+
+.public-badge {
+    background-color: rgba(0, 102, 255, 0.15);
+    color: var(--public-text);
+    border-radius: 999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+}
+
+.public-sidebar {
+    background-color: rgba(255, 255, 255, 0.04);
+    border-radius: 16px;
+    padding: 1.5rem;
+}
+
+.public-sidebar a {
+    color: var(--public-text);
+    text-decoration: none;
+}
+
+.public-sidebar a:hover {
+    color: var(--public-accent);
+}
+
+.public-footer {
+    background-color: #090b10;
+    flex-shrink: 0;
+}
+
+.navbar-dark .navbar-nav .nav-link {
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.navbar-dark .navbar-nav .nav-link:hover {
+    color: #ffffff;
+}
+
+.public-hero {
+    background: radial-gradient(circle at top left, rgba(0, 102, 255, 0.35), transparent 55%),
+                radial-gradient(circle at bottom right, rgba(0, 102, 255, 0.15), transparent 65%);
+    border-radius: 24px;
+    padding: 3rem;
+    color: var(--public-text);
+    margin-bottom: 2rem;
+}
+
+.public-hero h1 {
+    font-weight: 600;
+}
+
+.public-hero p {
+    color: var(--public-muted);
+}
+
+.public-article img {
+    border-radius: 18px;
+}
+
+.public-article p,
+.public-article ul,
+.public-article ol {
+    color: var(--public-text);
+    line-height: 1.7;
+}
+
+.public-article a {
+    color: var(--public-accent);
+}
+
+.public-article blockquote {
+    border-left: 3px solid var(--public-accent);
+    padding-left: 1.25rem;
+    color: var(--public-muted);
+    font-style: italic;
+}
+
+.public-pagination .page-link {
+    background-color: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: var(--public-text);
+}
+
+.public-pagination .page-link:hover {
+    background-color: rgba(0, 102, 255, 0.2);
+    border-color: rgba(0, 102, 255, 0.5);
+}
+
+.public-pagination .page-item.active .page-link {
+    background-color: var(--public-accent);
+    border-color: var(--public-accent);
+}
+
+.public-related-item {
+    background-color: rgba(255, 255, 255, 0.04);
+    border-radius: 14px;
+    padding: 1rem;
+    transition: background-color 0.2s ease;
+}
+
+.public-related-item:hover {
+    background-color: rgba(0, 102, 255, 0.16);
+}
+
+.public-badge-category {
+    background-color: rgba(0, 102, 255, 0.2);
+    color: var(--public-text);
+    border-radius: 12px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+}
+
+@media (max-width: 767px) {
+    .public-hero {
+        padding: 2rem;
+    }
+}

--- a/blog/.htaccess
+++ b/blog/.htaccess
@@ -1,0 +1,5 @@
+RewriteEngine On
+RewriteRule ^$ index.php [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.+)$ index.php?slug=$1 [QSA,L]

--- a/blog/index.php
+++ b/blog/index.php
@@ -1,0 +1,203 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+use App\Blog\BlogRepository;
+use App\Helpers;
+use App\Lang;
+
+Lang::boot();
+
+$slug = isset($_GET['slug']) ? trim((string)$_GET['slug']) : '';
+$slug = trim($slug, '/');
+
+$categorySlug = isset($_GET['category']) ? trim((string)$_GET['category']) : '';
+$page = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
+$perPage = 9;
+$offset = ($page - 1) * $perPage;
+
+if ($slug !== '') {
+    $post = BlogRepository::findPostBySlug($slug, true);
+
+    if (!$post) {
+        http_response_code(404);
+        $pageTitle = 'Yazı bulunamadı';
+        Helpers::includeTemplate('public-header.php', array('pageTitle' => $pageTitle));
+        ?>
+        <div class="public-hero text-center">
+            <h1 class="display-5 mb-3">Yazı bulunamadı</h1>
+            <p class="lead">Aradığınız içerik yayından kaldırılmış veya taşınmış olabilir.</p>
+            <a class="btn btn-primary mt-3" href="/blog/">Blog ana sayfasına dön</a>
+        </div>
+        <?php
+        Helpers::includeTemplate('public-footer.php');
+        exit;
+    }
+
+    $metaDescription = $post['meta_description'] ?: ($post['excerpt'] ?: Helpers::seoDescription());
+    $pageTitle = $post['meta_title'] ?: $post['title'];
+    $categories = BlogRepository::categories();
+    $related = BlogRepository::relatedPosts((int)$post['id'], isset($post['category_id']) ? (int)$post['category_id'] : null, 4);
+
+    Helpers::includeTemplate('public-header.php', array(
+        'pageTitle' => $pageTitle,
+        'metaDescription' => $metaDescription,
+    ));
+    ?>
+    <article class="public-article">
+        <div class="row g-5">
+            <div class="col-lg-8">
+                <div class="public-hero">
+                    <?php if (!empty($post['category_name'])): ?>
+                        <span class="public-badge-category mb-3 d-inline-flex align-items-center"><i class="bi bi-folder2 me-2"></i><?= Helpers::sanitize($post['category_name']) ?></span>
+                    <?php endif; ?>
+                    <h1 class="display-5 mb-3"><?= Helpers::sanitize($post['title']) ?></h1>
+                    <div class="public-card-meta d-flex gap-3 flex-wrap">
+                        <?php if (!empty($post['author_name'])): ?>
+                            <span><i class="bi bi-person me-2"></i><?= Helpers::sanitize($post['author_name']) ?></span>
+                        <?php endif; ?>
+                        <span><i class="bi bi-calendar-event me-2"></i><?= Helpers::sanitize(date('d F Y', strtotime($post['published_at'] ?: $post['created_at']))) ?></span>
+                    </div>
+                </div>
+
+                <?php if (!empty($post['image_url'])): ?>
+                    <img src="<?= Helpers::sanitize($post['image_url'] ?? '') ?>" class="img-fluid mb-4" alt="<?= Helpers::sanitize($post['title']) ?>">
+                <?php endif; ?>
+
+                <div class="public-card p-4 public-article-content">
+                    <?= $post['content'] ?>
+                </div>
+            </div>
+            <div class="col-lg-4">
+                <aside class="public-sidebar mb-4">
+                    <h5 class="mb-3">Kategoriler</h5>
+                    <ul class="list-unstyled mb-0">
+                        <?php foreach ($categories as $category): ?>
+                            <li class="mb-2">
+                                <a href="/blog/?category=<?= rawurlencode($category['slug']) ?>">
+                                    <?= Helpers::sanitize($category['name']) ?>
+                                    <span class="badge bg-secondary ms-2"><?= (int)$category['post_count'] ?></span>
+                                </a>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </aside>
+
+                <?php if ($related): ?>
+                    <div class="public-sidebar">
+                        <h5 class="mb-3">Benzer Yazılar</h5>
+                        <div class="d-grid gap-3">
+                            <?php foreach ($related as $item): ?>
+                                <a href="/blog/<?= rawurlencode($item['slug']) ?>" class="public-related-item text-decoration-none d-block">
+                                    <div class="fw-semibold mb-1 text-white"><?= Helpers::sanitize($item['title']) ?></div>
+                                    <div class="small text-muted">
+                                        <?= Helpers::sanitize(date('d.m.Y', strtotime($item['published_at'] ?: $item['created_at']))) ?>
+                                    </div>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </article>
+    <?php
+    Helpers::includeTemplate('public-footer.php');
+    exit;
+}
+
+$selectedCategory = null;
+if ($categorySlug !== '') {
+    $selectedCategory = BlogRepository::findCategoryBySlug($categorySlug);
+}
+
+$categories = BlogRepository::categories();
+$categoryId = $selectedCategory ? (int)$selectedCategory['id'] : null;
+$posts = BlogRepository::listPosts($perPage, $offset, $categoryId, true);
+$totalPosts = BlogRepository::countPosts($categoryId, true);
+$totalPages = $totalPosts > 0 ? (int)ceil($totalPosts / $perPage) : 1;
+
+$heroTitle = $selectedCategory ? $selectedCategory['name'] : 'Blog Yazıları';
+$heroDescription = $selectedCategory && !empty($selectedCategory['description'])
+    ? $selectedCategory['description']
+    : 'E-Pin, oyun hesapları ve dijital ürünler dünyasından ipuçları, kampanyalar ve güncel duyurular.';
+
+Helpers::includeTemplate('public-header.php', array(
+    'pageTitle' => $selectedCategory ? ($selectedCategory['meta_title'] ?: $selectedCategory['name']) : 'Blog',
+    'metaDescription' => $selectedCategory ? ($selectedCategory['meta_description'] ?: Helpers::seoDescription()) : Helpers::seoDescription(),
+));
+?>
+<section class="public-hero">
+    <h1 class="display-5 mb-3"><?= Helpers::sanitize($heroTitle) ?></h1>
+    <p class="lead mb-0"><?= Helpers::sanitize($heroDescription) ?></p>
+</section>
+<div class="row g-4">
+    <div class="col-lg-8">
+        <div class="row g-4">
+            <?php if (!$posts): ?>
+                <div class="col-12">
+                    <div class="public-card p-5 text-center text-muted">
+                        Henüz yayınlanmış blog içeriği bulunmuyor.
+                    </div>
+                </div>
+            <?php else: ?>
+                <?php foreach ($posts as $post): ?>
+                    <?php $summary = $post['excerpt'] ?: Helpers::truncate(strip_tags($post['content'] ?? ''), 140); ?>
+                    <div class="col-md-6">
+                        <article class="public-card h-100">
+                            <?php if (!empty($post['image_url'])): ?>
+                                <img src="<?= Helpers::sanitize($post['image_url'] ?? '') ?>" class="w-100" alt="<?= Helpers::sanitize($post['title']) ?>" height="200">
+                            <?php endif; ?>
+                            <div class="p-4 d-flex flex-column h-100">
+                                <?php if (!empty($post['category_name'])): ?>
+                                    <span class="public-badge align-self-start mb-2 text-uppercase small"><?= Helpers::sanitize($post['category_name']) ?></span>
+                                <?php endif; ?>
+                                <h2 class="h5 public-card-title mb-3"><?= Helpers::sanitize($post['title']) ?></h2>
+                                <p class="public-card-meta mb-4 flex-grow-1"><?= Helpers::sanitize($summary) ?></p>
+                                <div class="d-flex justify-content-between align-items-center text-muted small">
+                                    <span><i class="bi bi-calendar-event me-2"></i><?= Helpers::sanitize(date('d.m.Y', strtotime($post['published_at'] ?: $post['created_at']))) ?></span>
+                                    <a class="btn btn-sm btn-outline-light" href="/blog/<?= rawurlencode($post['slug']) ?>">Devamını oku</a>
+                                </div>
+                            </div>
+                        </article>
+                    </div>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </div>
+
+        <?php if ($totalPages > 1): ?>
+            <nav class="public-pagination mt-4">
+                <ul class="pagination">
+                    <?php for ($i = 1; $i <= $totalPages; $i++): ?>
+                        <?php
+                        $params = array('page' => $i);
+                        if ($selectedCategory) {
+                            $params['category'] = $selectedCategory['slug'];
+                        }
+                        $query = http_build_query($params);
+                        ?>
+                        <li class="page-item <?= $i === $page ? 'active' : '' ?>">
+                            <a class="page-link" href="/blog/?<?= Helpers::sanitize($query) ?>"><?= $i ?></a>
+                        </li>
+                    <?php endfor; ?>
+                </ul>
+            </nav>
+        <?php endif; ?>
+    </div>
+    <div class="col-lg-4">
+        <aside class="public-sidebar">
+            <h5 class="mb-3">Kategoriler</h5>
+            <ul class="list-unstyled mb-0">
+                <?php foreach ($categories as $category): ?>
+                    <li class="mb-2">
+                        <a href="/blog/?category=<?= rawurlencode($category['slug']) ?>" class="d-flex justify-content-between align-items-center">
+                            <span><?= Helpers::sanitize($category['name']) ?></span>
+                            <span class="badge bg-secondary"><?= (int)$category['post_count'] ?></span>
+                        </a>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        </aside>
+    </div>
+</div>
+<?php
+Helpers::includeTemplate('public-footer.php');

--- a/customer/dashboard.php
+++ b/customer/dashboard.php
@@ -1,6 +1,7 @@
 <?php
 require __DIR__ . '/../bootstrap.php';
 
+use App\Blog\BlogRepository;
 use App\Customers\CustomerAuth;
 use App\Customers\OrderService;
 use App\Customers\WalletService;
@@ -21,6 +22,7 @@ $openTickets = (int)$ticketStmt->fetchColumn();
 
 $recentOrders = OrderService::listForCustomer((int)$customer['id'], 5);
 $walletHistory = WalletService::history((int)$customer['id'], 5);
+$blogPosts = BlogRepository::latestPosts(3);
 
 $pageTitle = 'Dashboard';
 require __DIR__ . '/../templates/customer-header.php';
@@ -128,6 +130,31 @@ require __DIR__ . '/../templates/customer-header.php';
                 <a href="/customer/support.php" class="btn btn-outline-secondary"><i class="bi bi-life-preserver me-2"></i>Destek Talebi Aç</a>
             </div>
         </div>
+        <?php if ($blogPosts): ?>
+            <div class="card customer-card mt-4">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="card-title mb-0">Blog Duyuruları</h5>
+                    <a href="/blog/" class="btn btn-link btn-sm">Tümü</a>
+                </div>
+                <div class="card-body">
+                    <ul class="list-group list-group-flush">
+                        <?php foreach ($blogPosts as $post): ?>
+                            <li class="list-group-item bg-transparent d-flex justify-content-between align-items-center position-relative">
+                                <div>
+                                    <a href="/blog/<?= rawurlencode($post['slug']) ?>" class="stretched-link text-decoration-none fw-semibold">
+                                        <?= Helpers::sanitize($post['title']) ?>
+                                    </a>
+                                    <div class="text-muted small mt-1">
+                                        <?= Helpers::sanitize(date('d.m.Y', strtotime($post['published_at'] ?: $post['created_at']))) ?>
+                                    </div>
+                                </div>
+                                <i class="bi bi-chevron-right text-muted"></i>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            </div>
+        <?php endif; ?>
     </div>
 </div>
 <?php require __DIR__ . '/../templates/customer-footer.php';

--- a/schema.sql
+++ b/schema.sql
@@ -214,6 +214,39 @@ CREATE TABLE IF NOT EXISTS user_purchases (
     FOREIGN KEY (module_id) REFERENCES premium_modules(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS blog_categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    slug VARCHAR(191) NOT NULL,
+    description TEXT NULL,
+    meta_title VARCHAR(150) NULL,
+    meta_description VARCHAR(255) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_blog_category_slug (slug)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS blog_posts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    category_id INT NULL,
+    title VARCHAR(191) NOT NULL,
+    slug VARCHAR(191) NOT NULL,
+    excerpt TEXT NULL,
+    content MEDIUMTEXT NOT NULL,
+    image_url VARCHAR(255) NULL,
+    author_name VARCHAR(150) NULL,
+    status ENUM('draft','published') NOT NULL DEFAULT 'draft',
+    published_at DATETIME NULL,
+    meta_title VARCHAR(191) NULL,
+    meta_description VARCHAR(255) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (category_id) REFERENCES blog_categories(id) ON DELETE SET NULL,
+    UNIQUE KEY uniq_blog_post_slug (slug),
+    INDEX idx_blog_status (status),
+    INDEX idx_blog_category (category_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 
 INSERT INTO users (id, name, email, password_hash, role, balance, status, created_at)
 VALUES (

--- a/src/Migrations/Schema.php
+++ b/src/Migrations/Schema.php
@@ -26,6 +26,8 @@ final class Schema
         self::ensureApiRequestLogTable($pdo);
         self::ensureAutoTopupTable($pdo);
         self::ensureUserLocaleColumns($pdo);
+        self::ensureBlogCategoriesTable($pdo);
+        self::ensureBlogPostsTable($pdo);
 
     }
 
@@ -166,6 +168,53 @@ final class Schema
     {
         self::ensureColumn($pdo, 'users', 'locale', "VARCHAR(5) NULL");
         self::ensureColumn($pdo, 'users', 'currency', "VARCHAR(3) NULL");
+    }
+
+    private static function ensureBlogCategoriesTable(PDO $pdo): void
+    {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS blog_categories (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(150) NOT NULL,
+            slug VARCHAR(191) NOT NULL,
+            description TEXT NULL,
+            meta_title VARCHAR(150) NULL,
+            meta_description VARCHAR(255) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uniq_blog_category_slug (slug)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        self::ensureColumn($pdo, 'blog_categories', 'meta_title', 'VARCHAR(150) NULL');
+        self::ensureColumn($pdo, 'blog_categories', 'meta_description', 'VARCHAR(255) NULL');
+    }
+
+    private static function ensureBlogPostsTable(PDO $pdo): void
+    {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS blog_posts (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            category_id INT NULL,
+            title VARCHAR(191) NOT NULL,
+            slug VARCHAR(191) NOT NULL,
+            excerpt TEXT NULL,
+            content MEDIUMTEXT NOT NULL,
+            image_url VARCHAR(255) NULL,
+            author_name VARCHAR(150) NULL,
+            status ENUM('draft','published') NOT NULL DEFAULT 'draft',
+            published_at DATETIME NULL,
+            meta_title VARCHAR(191) NULL,
+            meta_description VARCHAR(255) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+            FOREIGN KEY (category_id) REFERENCES blog_categories(id) ON DELETE SET NULL,
+            UNIQUE KEY uniq_blog_post_slug (slug),
+            INDEX idx_blog_status (status),
+            INDEX idx_blog_category (category_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        self::ensureColumn($pdo, 'blog_posts', 'meta_title', 'VARCHAR(191) NULL');
+        self::ensureColumn($pdo, 'blog_posts', 'meta_description', 'VARCHAR(255) NULL');
+        self::ensureColumn($pdo, 'blog_posts', 'author_name', 'VARCHAR(150) NULL');
+        self::ensureColumn($pdo, 'blog_posts', 'image_url', 'VARCHAR(255) NULL');
     }
 
 

--- a/templates/customer-header.php
+++ b/templates/customer-header.php
@@ -58,6 +58,7 @@ $theme = isset($_COOKIE['customer_theme']) && $_COOKIE['customer_theme'] === 'da
             <a href="/customer/dashboard.php" class="customer-sidebar-link<?= Helpers::currentPath() === '/customer/dashboard.php' ? ' active' : '' ?>"><i class="bi bi-speedometer2 me-2"></i>Dashboard</a>
             <a href="/customer/orders.php" class="customer-sidebar-link<?= Helpers::currentPath() === '/customer/orders.php' ? ' active' : '' ?>"><i class="bi bi-receipt me-2"></i>Siparişler</a>
             <a href="/customer/new-order.php" class="customer-sidebar-link<?= Helpers::currentPath() === '/customer/new-order.php' ? ' active' : '' ?>"><i class="bi bi-cart-plus me-2"></i>Yeni Sipariş</a>
+            <a href="/blog/" class="customer-sidebar-link" target="_blank"><i class="bi bi-journal-text me-2"></i>Blog</a>
             <a href="/customer/profile.php" class="customer-sidebar-link<?= Helpers::currentPath() === '/customer/profile.php' ? ' active' : '' ?>"><i class="bi bi-person me-2"></i>Profil</a>
             <a href="/customer/wallet.php" class="customer-sidebar-link<?= Helpers::currentPath() === '/customer/wallet.php' ? ' active' : '' ?>"><i class="bi bi-wallet2 me-2"></i>Cüzdan</a>
             <a href="/customer/support.php" class="customer-sidebar-link<?= Helpers::currentPath() === '/customer/support.php' ? ' active' : '' ?>"><i class="bi bi-life-preserver me-2"></i>Destek</a>

--- a/templates/header.php
+++ b/templates/header.php
@@ -87,6 +87,13 @@ if ($user) {
                 ),
             ),
             array(
+                'heading' => 'İçerik Yönetimi',
+                'items' => array(
+                    array('label' => 'Blog Yazıları', 'href' => '/admin/blog-posts.php', 'pattern' => '/admin/blog-posts.php', 'icon' => 'bi-journal-text', 'roles' => array('super_admin', 'admin', 'content')),
+                    array('label' => 'Blog Kategorileri', 'href' => '/admin/blog-categories.php', 'pattern' => '/admin/blog-categories.php', 'icon' => 'bi-tags', 'roles' => array('super_admin', 'admin', 'content')),
+                ),
+            ),
+            array(
                 'heading' => 'Entegrasyon & API',
                 'items' => array(
                     array('label' => 'API Anahtarları', 'href' => '/admin/api-keys.php', 'pattern' => '/admin/api-keys.php', 'icon' => 'bi-key', 'roles' => array('super_admin', 'admin')),

--- a/templates/public-footer.php
+++ b/templates/public-footer.php
@@ -1,0 +1,11 @@
+<?php use App\Helpers; ?>
+    </div>
+</main>
+<footer class="public-footer py-4">
+    <div class="container text-center text-muted small">
+        &copy; <?= date('Y') ?> <?= Helpers::sanitize($siteName) ?>. Tüm hakları saklıdır.
+    </div>
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/public-header.php
+++ b/templates/public-header.php
@@ -1,0 +1,45 @@
+<?php
+use App\Helpers;
+use App\Lang;
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+Lang::boot();
+
+$siteName = Helpers::siteName();
+$pageTitle = isset($pageTitle) && $pageTitle ? $pageTitle : 'Blog';
+$metaDescription = isset($metaDescription) && $metaDescription ? $metaDescription : Helpers::seoDescription();
+$metaKeywords = isset($metaKeywords) && $metaKeywords ? $metaKeywords : Helpers::seoKeywords();
+?>
+<!DOCTYPE html>
+<html lang="<?= Lang::htmlLocale() ?>">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= Helpers::sanitize($pageTitle) ?> | <?= Helpers::sanitize($siteName) ?></title>
+    <meta name="description" content="<?= Helpers::sanitize($metaDescription) ?>">
+    <meta name="keywords" content="<?= Helpers::sanitize($metaKeywords) ?>">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="/assets/css/public.css">
+</head>
+<body class="public-app">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark py-3 shadow-sm">
+    <div class="container">
+        <a class="navbar-brand fw-semibold" href="/blog/"><?= Helpers::sanitize($siteName) ?></a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#publicNav" aria-controls="publicNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="publicNav">
+            <ul class="navbar-nav ms-auto align-items-lg-center gap-lg-3">
+                <li class="nav-item"><a class="nav-link" href="/">Bayi Girişi</a></li>
+                <li class="nav-item"><a class="nav-link" href="/customer/login.php">Müşteri Girişi</a></li>
+                <li class="nav-item"><a class="nav-link" href="/register.php">Bayi Kaydı</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<main class="public-main py-5">
+    <div class="container">


### PR DESCRIPTION
## Summary
- introduce a BlogRepository with helpers and schema migrations for blog categories and posts
- add admin panels for managing blog posts and categories with navigation updates
- build public-facing blog pages with new styling and surface recent posts in the customer dashboard

## Testing
- php -l app/Blog/BlogRepository.php
- php -l admin/blog-posts.php
- php -l admin/blog-categories.php
- php -l blog/index.php
- php -l customer/dashboard.php

------
https://chatgpt.com/codex/tasks/task_b_68e15ccd0a3083219d47372d37947359