### PR TITLE
Add standalone customer-facing E-PIN storefront

### DIFF
--- a/epin_client/api/_bootstrap.php
+++ b/epin_client/api/_bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/bootstrap.php';
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Pragma: no-cache');

--- a/epin_client/api/add_balance.php
+++ b/epin_client/api/add_balance.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_post();
+require_auth();
+
+$amount = isset($_POST['amount']) ? (float)$_POST['amount'] : 0.0;
+$method = trim((string)($_POST['method'] ?? ''));
+$token = $_POST['csrf_token'] ?? null;
+
+if (!verify_csrf($token)) {
+    json_response(['success' => false, 'message' => 'CSRF doğrulaması başarısız.'], 400);
+}
+
+if ($amount < 10) {
+    json_response(['success' => false, 'message' => 'Minimum yükleme tutarı 10 TL olmalıdır.'], 422);
+}
+
+if ($method === '') {
+    json_response(['success' => false, 'message' => 'Ödeme yöntemi seçiniz.'], 422);
+}
+
+$pdo = db();
+$insert = $pdo->prepare('INSERT INTO payments (user_id, amount, method, status, created_at) VALUES (:user_id, :amount, :method, :status, NOW())');
+$insert->execute([
+    'user_id' => (int)session_get('user_id'),
+    'amount' => $amount,
+    'method' => $method,
+    'status' => 'pending',
+]);
+
+json_response(['success' => true, 'message' => 'Talebiniz alındı. Ödeme onaylandığında bakiyenize yansıtılacaktır.']);

--- a/epin_client/api/create_ticket.php
+++ b/epin_client/api/create_ticket.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_post();
+require_auth();
+
+$subject = trim((string)($_POST['subject'] ?? ''));
+$message = trim((string)($_POST['message'] ?? ''));
+$token = $_POST['csrf_token'] ?? null;
+
+if (!verify_csrf($token)) {
+    json_response(['success' => false, 'message' => 'CSRF doğrulaması başarısız.'], 400);
+}
+
+if ($subject === '' || $message === '') {
+    json_response(['success' => false, 'message' => 'Lütfen konu ve mesaj alanlarını doldurun.'], 422);
+}
+
+$pdo = db();
+$stmt = $pdo->prepare('INSERT INTO tickets (user_id, subject, message, status, created_at) VALUES (:user_id, :subject, :message, :status, NOW())');
+$stmt->execute([
+    'user_id' => (int)session_get('user_id'),
+    'subject' => $subject,
+    'message' => $message,
+    'status' => 'open',
+]);
+
+json_response(['success' => true]);

--- a/epin_client/api/dashboard_stats.php
+++ b/epin_client/api/dashboard_stats.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_auth();
+
+$pdo = db();
+$userId = (int)session_get('user_id');
+
+$balanceStmt = $pdo->prepare('SELECT balance FROM users WHERE id = :id');
+$balanceStmt->execute(['id' => $userId]);
+$balance = $balanceStmt->fetchColumn();
+
+$orderStmt = $pdo->prepare('SELECT COUNT(*) FROM orders WHERE user_id = :user_id');
+$orderStmt->execute(['user_id' => $userId]);
+$orderCount = (int)$orderStmt->fetchColumn();
+
+$ticketStmt = $pdo->prepare('SELECT COUNT(*) FROM tickets WHERE user_id = :user_id AND status != "closed"');
+$ticketStmt->execute(['user_id' => $userId]);
+$openTickets = (int)$ticketStmt->fetchColumn();
+
+$quickStmt = $pdo->prepare('SELECT id, name, price, stock, description FROM products ORDER BY id DESC LIMIT 6');
+try {
+    $quickStmt->execute();
+    $quickProductsRaw = $quickStmt->fetchAll();
+} catch (PDOException) {
+    $quickProductsRaw = [];
+}
+
+$quickProducts = array_map(static function (array $product): array {
+    return [
+        'id' => (int)$product['id'],
+        'name' => sanitize($product['name']),
+        'price' => number_format((float)$product['price'], 2, '.', ''),
+        'stock' => (int)$product['stock'],
+        'description' => sanitize($product['description'] ?? ''),
+    ];
+}, $quickProductsRaw);
+
+json_response([
+    'balance' => number_format((float)$balance, 2, '.', ''),
+    'order_count' => $orderCount,
+    'open_tickets' => $openTickets,
+    'quick_products' => $quickProducts,
+]);

--- a/epin_client/api/get_balance.php
+++ b/epin_client/api/get_balance.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_auth();
+
+$pdo = db();
+$stmt = $pdo->prepare('SELECT balance FROM users WHERE id = :id');
+$stmt->execute(['id' => (int)session_get('user_id')]);
+$balance = $stmt->fetchColumn();
+
+json_response(['balance' => number_format((float)$balance, 2, '.', '')]);

--- a/epin_client/api/get_orders.php
+++ b/epin_client/api/get_orders.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_auth();
+
+$pdo = db();
+$userId = (int)session_get('user_id');
+$stmt = $pdo->prepare('SELECT o.id, o.status, o.created_at, p.name AS product_name, pn.pin_code FROM orders o INNER JOIN products p ON p.id = o.product_id LEFT JOIN pins pn ON pn.id = o.pin_id WHERE o.user_id = :user_id ORDER BY o.created_at DESC');
+$stmt->execute(['user_id' => $userId]);
+
+$statusLabels = [
+    'completed' => 'Tamamlandı',
+    'pending' => 'Beklemede',
+    'cancelled' => 'İptal',
+];
+
+$orders = [];
+foreach ($stmt->fetchAll() as $order) {
+    $status = $order['status'] ?? 'completed';
+    $orders[] = [
+        'id' => (int)$order['id'],
+        'product_name' => sanitize($order['product_name'] ?? ''),
+        'created_at' => $order['created_at'],
+        'status' => $status,
+        'status_label' => $statusLabels[$status] ?? ucfirst($status),
+        'pin_code' => $order['pin_code'] ? sanitize($order['pin_code']) : null,
+    ];
+}
+
+json_response(['orders' => $orders]);

--- a/epin_client/api/get_products.php
+++ b/epin_client/api/get_products.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+
+$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 0;
+$query = 'SELECT id, name, price, stock, description FROM products WHERE stock > 0 ORDER BY name ASC';
+if ($limit > 0) {
+    $query .= ' LIMIT :limit';
+}
+
+$pdo = db();
+$stmt = $pdo->prepare($query);
+if ($limit > 0) {
+    $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+}
+$stmt->execute();
+$products = array_map(static function (array $product): array {
+    return [
+        'id' => (int)$product['id'],
+        'name' => sanitize($product['name']),
+        'price' => number_format((float)$product['price'], 2, '.', ''),
+        'stock' => (int)$product['stock'],
+        'description' => sanitize($product['description'] ?? ''),
+    ];
+}, $stmt->fetchAll());
+
+json_response(['products' => $products]);

--- a/epin_client/api/get_tickets.php
+++ b/epin_client/api/get_tickets.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_auth();
+
+$pdo = db();
+$hasAdminResponse = false;
+try {
+    $columnCheck = $pdo->query("SHOW COLUMNS FROM tickets LIKE 'admin_response'");
+    $hasAdminResponse = (bool)$columnCheck->fetch();
+} catch (PDOException) {
+    $hasAdminResponse = false;
+}
+
+$fields = 'id, subject, message, status, created_at';
+if ($hasAdminResponse) {
+    $fields .= ', admin_response';
+}
+
+$stmt = $pdo->prepare("SELECT $fields FROM tickets WHERE user_id = :user_id ORDER BY created_at DESC");
+$stmt->execute(['user_id' => (int)session_get('user_id')]);
+
+$statusLabels = [
+    'open' => 'Açık',
+    'answered' => 'Yanıtlandı',
+    'closed' => 'Kapalı',
+];
+
+$tickets = [];
+foreach ($stmt->fetchAll() as $ticket) {
+    $status = $ticket['status'] ?? 'open';
+    $tickets[] = [
+        'id' => (int)$ticket['id'],
+        'subject' => sanitize($ticket['subject'] ?? ''),
+        'message' => nl2br(sanitize($ticket['message'] ?? '')),
+        'status' => $status,
+        'status_label' => $statusLabels[$status] ?? ucfirst($status),
+        'created_at' => $ticket['created_at'],
+        'admin_response' => $hasAdminResponse && isset($ticket['admin_response']) && $ticket['admin_response'] !== null
+            ? nl2br(sanitize($ticket['admin_response']))
+            : null,
+    ];
+}
+
+json_response(['tickets' => $tickets]);

--- a/epin_client/api/login.php
+++ b/epin_client/api/login.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_post();
+
+$email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+$password = (string)($_POST['password'] ?? '');
+$token = $_POST['csrf_token'] ?? null;
+
+if (!verify_csrf($token)) {
+    json_response(['success' => false, 'message' => 'Güvenlik doğrulaması başarısız.'], 400);
+}
+
+if (!$email || $password === '') {
+    json_response(['success' => false, 'message' => 'E-posta ve şifre gereklidir.'], 422);
+}
+
+if (!attempt_login($email, $password)) {
+    json_response(['success' => false, 'message' => 'Bilgiler doğrulanamadı.'], 401);
+}
+
+json_response(['success' => true]);

--- a/epin_client/api/logout.php
+++ b/epin_client/api/logout.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_post();
+
+if (!verify_csrf($_POST['csrf_token'] ?? null)) {
+    json_response(['success' => false, 'message' => 'CSRF doğrulaması başarısız.'], 400);
+}
+
+logout();
+json_response(['success' => true]);

--- a/epin_client/api/order_create.php
+++ b/epin_client/api/order_create.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_post();
+require_auth();
+
+$productId = isset($_POST['product_id']) ? (int)$_POST['product_id'] : 0;
+$token = $_POST['csrf_token'] ?? null;
+
+if (!verify_csrf($token)) {
+    json_response(['success' => false, 'message' => 'CSRF doğrulaması başarısız.'], 400);
+}
+
+if ($productId <= 0) {
+    json_response(['success' => false, 'message' => 'Geçersiz ürün.'], 422);
+}
+
+$pdo = db();
+$userId = (int)session_get('user_id');
+
+try {
+    $pdo->beginTransaction();
+
+    $userStmt = $pdo->prepare('SELECT balance FROM users WHERE id = :id FOR UPDATE');
+    $userStmt->execute(['id' => $userId]);
+    $user = $userStmt->fetch();
+    if (!$user) {
+        $pdo->rollBack();
+        json_response(['success' => false, 'message' => 'Kullanıcı bulunamadı.'], 404);
+    }
+
+    $productStmt = $pdo->prepare('SELECT id, name, price FROM products WHERE id = :id FOR UPDATE');
+    $productStmt->execute(['id' => $productId]);
+    $product = $productStmt->fetch();
+    if (!$product) {
+        $pdo->rollBack();
+        json_response(['success' => false, 'message' => 'Ürün bulunamadı.'], 404);
+    }
+
+    if ((float)$user['balance'] < (float)$product['price']) {
+        $pdo->rollBack();
+        json_response(['success' => false, 'message' => 'Yetersiz bakiye.'], 400);
+    }
+
+    $pinStmt = $pdo->prepare('SELECT id, pin_code FROM pins WHERE product_id = :product_id AND status = "available" LIMIT 1 FOR UPDATE');
+    $pinStmt->execute(['product_id' => $productId]);
+    $pin = $pinStmt->fetch();
+
+    if (!$pin) {
+        $pdo->rollBack();
+        json_response(['success' => false, 'message' => 'Stokta PIN bulunamadı.'], 400);
+    }
+
+    $updateBalance = $pdo->prepare('UPDATE users SET balance = balance - :amount WHERE id = :id');
+    $updateBalance->execute([
+        'amount' => $product['price'],
+        'id' => $userId,
+    ]);
+
+    $updatePin = $pdo->prepare('UPDATE pins SET status = "used" WHERE id = :id');
+    $updatePin->execute(['id' => $pin['id']]);
+
+    $updateProduct = $pdo->prepare('UPDATE products SET stock = GREATEST(stock - 1, 0) WHERE id = :id');
+    $updateProduct->execute(['id' => $productId]);
+
+    $orderStmt = $pdo->prepare('INSERT INTO orders (user_id, product_id, pin_id, status, created_at) VALUES (:user_id, :product_id, :pin_id, :status, NOW())');
+    $orderStmt->execute([
+        'user_id' => $userId,
+        'product_id' => $productId,
+        'pin_id' => $pin['id'],
+        'status' => 'completed',
+    ]);
+
+    $pdo->commit();
+
+    json_response([
+        'success' => true,
+        'pin_code' => sanitize($pin['pin_code']),
+    ]);
+} catch (Throwable $exception) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    json_response(['success' => false, 'message' => 'Sipariş oluşturulamadı.'], 500);
+}

--- a/epin_client/api/register.php
+++ b/epin_client/api/register.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_post();
+
+$name = trim((string)($_POST['name'] ?? ''));
+$email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+$password = (string)($_POST['password'] ?? '');
+$passwordConfirm = (string)($_POST['password_confirm'] ?? '');
+$token = $_POST['csrf_token'] ?? null;
+
+if (!verify_csrf($token)) {
+    json_response(['success' => false, 'message' => 'Güvenlik doğrulaması başarısız.'], 400);
+}
+
+if (!$name || !$email || $password === '') {
+    json_response(['success' => false, 'message' => 'Tüm alanlar zorunludur.'], 422);
+}
+
+if (mb_strlen($password) < 6) {
+    json_response(['success' => false, 'message' => 'Şifre en az 6 karakter olmalıdır.'], 422);
+}
+
+if ($password !== $passwordConfirm) {
+    json_response(['success' => false, 'message' => 'Şifreler eşleşmiyor.'], 422);
+}
+
+$result = register_user($name, $email, $password);
+
+json_response($result['success'] ? ['success' => true] : ['success' => false, 'message' => $result['message'] ?? 'Kayıt başarısız.']);

--- a/epin_client/api/update_password.php
+++ b/epin_client/api/update_password.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_post();
+require_auth();
+
+$current = (string)($_POST['current_password'] ?? '');
+$new = (string)($_POST['new_password'] ?? '');
+$confirm = (string)($_POST['new_password_confirm'] ?? '');
+$token = $_POST['csrf_token'] ?? null;
+
+if (!verify_csrf($token)) {
+    json_response(['success' => false, 'message' => 'CSRF doğrulaması başarısız.'], 400);
+}
+
+if ($current === '' || $new === '') {
+    json_response(['success' => false, 'message' => 'Tüm alanları doldurun.'], 422);
+}
+
+if (mb_strlen($new) < 6) {
+    json_response(['success' => false, 'message' => 'Yeni şifre en az 6 karakter olmalıdır.'], 422);
+}
+
+if ($new !== $confirm) {
+    json_response(['success' => false, 'message' => 'Yeni şifreler eşleşmiyor.'], 422);
+}
+
+$pdo = db();
+$userId = (int)session_get('user_id');
+$stmt = $pdo->prepare('SELECT password_hash FROM users WHERE id = :id');
+$stmt->execute(['id' => $userId]);
+$user = $stmt->fetch();
+
+if (!$user || !password_verify($current, $user['password_hash'])) {
+    json_response(['success' => false, 'message' => 'Mevcut şifre hatalı.'], 422);
+}
+
+$update = $pdo->prepare('UPDATE users SET password_hash = :hash WHERE id = :id');
+$update->execute([
+    'hash' => password_hash($new, PASSWORD_BCRYPT),
+    'id' => $userId,
+]);
+
+json_response(['success' => true]);

--- a/epin_client/api/update_profile.php
+++ b/epin_client/api/update_profile.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_bootstrap.php';
+require_post();
+require_auth();
+
+$name = trim((string)($_POST['name'] ?? ''));
+$email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+$token = $_POST['csrf_token'] ?? null;
+
+if (!verify_csrf($token)) {
+    json_response(['success' => false, 'message' => 'CSRF doğrulaması başarısız.'], 400);
+}
+
+if ($name === '' || !$email) {
+    json_response(['success' => false, 'message' => 'Geçerli bir ad ve e-posta giriniz.'], 422);
+}
+
+$pdo = db();
+$userId = (int)session_get('user_id');
+
+$exists = $pdo->prepare('SELECT id FROM users WHERE email = :email AND id != :id LIMIT 1');
+$exists->execute(['email' => $email, 'id' => $userId]);
+if ($exists->fetch()) {
+    json_response(['success' => false, 'message' => 'Bu e-posta adresi başka bir hesap tarafından kullanılıyor.'], 422);
+}
+
+$update = $pdo->prepare('UPDATE users SET name = :name, email = :email WHERE id = :id');
+$update->execute([
+    'name' => $name,
+    'email' => $email,
+    'id' => $userId,
+]);
+
+json_response(['success' => true]);

--- a/epin_client/assets/css/app.css
+++ b/epin_client/assets/css/app.css
@@ -1,0 +1,52 @@
+body {
+    background-color: #f5f7fb;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.navbar-brand {
+    font-weight: 700;
+    letter-spacing: 0.5px;
+}
+
+.dashboard-card .icon-circle {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    margin: 0 auto;
+}
+
+.card {
+    border: none;
+}
+
+#product-list .card,
+#quick-products .card {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#product-list .card:hover,
+#quick-products .card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.08);
+}
+
+.list-group-item + .list-group-item {
+    margin-top: 0.75rem;
+    border-top: 1px solid rgba(0,0,0,0.05);
+}
+
+.ticket-status {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+}
+
+footer {
+    margin-top: auto;
+}

--- a/epin_client/assets/js/app.js
+++ b/epin_client/assets/js/app.js
@@ -1,0 +1,382 @@
+(function ($) {
+    'use strict';
+
+    const endpoints = {
+        login: '/epin_client/api/login.php',
+        register: '/epin_client/api/register.php',
+        logout: '/epin_client/api/logout.php',
+        products: '/epin_client/api/get_products.php',
+        orderCreate: '/epin_client/api/order_create.php',
+        orders: '/epin_client/api/get_orders.php',
+        stats: '/epin_client/api/dashboard_stats.php',
+        balance: '/epin_client/api/get_balance.php',
+        payment: '/epin_client/api/add_balance.php',
+        tickets: '/epin_client/api/get_tickets.php',
+        ticketCreate: '/epin_client/api/create_ticket.php',
+        profileUpdate: '/epin_client/api/update_profile.php',
+        passwordUpdate: '/epin_client/api/update_password.php'
+    };
+
+    function handleError($el, message) {
+        $el.text(message).removeClass('d-none');
+    }
+
+    function clearAlert($el) {
+        $el.addClass('d-none').text('');
+    }
+
+    function fetchProducts(targetSelector, limit) {
+        const $container = $(targetSelector);
+        if (!$container.length) return;
+        $.getJSON(endpoints.products, { limit: limit || '' })
+            .done(function (response) {
+                $container.empty();
+                if (!response.products || !response.products.length) {
+                    $container.append('<div class="col-12 text-center text-muted">Ürün bulunamadı.</div>');
+                    return;
+                }
+                response.products.forEach(function (product) {
+                    const disabled = product.stock <= 0 ? 'disabled' : '';
+                    const card = `
+                        <div class="col-md-4">
+                            <div class="card h-100 shadow-sm">
+                                <div class="card-body d-flex flex-column">
+                                    <h5 class="card-title mb-2">${product.name}</h5>
+                                    <p class="text-muted flex-grow-1">${product.description || ''}</p>
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <div>
+                                            <span class="badge bg-success">₺${product.price}</span>
+                                            <span class="badge bg-secondary">Stok: ${product.stock}</span>
+                                        </div>
+                                        <button class="btn btn-primary btn-sm buy-product" data-id="${product.id}" ${disabled}>
+                                            <i class="fa-solid fa-cart-plus me-1"></i>Satın Al
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>`;
+                    $container.append(card);
+                });
+            })
+            .fail(function () {
+                $container.html('<div class="col-12 text-center text-danger">Ürünler yüklenirken hata oluştu.</div>');
+            });
+    }
+
+    function fetchOrders() {
+        const $tableBody = $('#orders-table tbody');
+        if (!$tableBody.length) return;
+        $.getJSON(endpoints.orders)
+            .done(function (response) {
+                $tableBody.empty();
+                if (!response.orders || !response.orders.length) {
+                    $('#orders-empty').removeClass('d-none');
+                    return;
+                }
+                $('#orders-empty').addClass('d-none');
+                response.orders.forEach(function (order) {
+                    const row = `
+                        <tr>
+                            <td>${order.id}</td>
+                            <td>${order.product_name}</td>
+                            <td>${order.created_at}</td>
+                            <td><span class="badge bg-${order.status === 'completed' ? 'success' : 'secondary'}">${order.status_label}</span></td>
+                            <td><code>${order.pin_code || '-'}</code></td>
+                        </tr>`;
+                    $tableBody.append(row);
+                });
+            })
+            .fail(function () {
+                $('#orders-empty').text('Siparişler yüklenemedi.');
+            });
+    }
+
+    function fetchStats() {
+        if (!$('#total-orders').length) return;
+        $.getJSON(endpoints.stats)
+            .done(function (response) {
+                if (typeof response.balance !== 'undefined') {
+                    $('#balance-amount').text('₺' + response.balance);
+                }
+                $('#total-orders').text(response.order_count || 0);
+                $('#open-tickets').text(response.open_tickets || 0);
+                if (response.quick_products) {
+                    const $quick = $('#quick-products').empty();
+                    response.quick_products.forEach(function (product) {
+                        const disabled = product.stock <= 0 ? 'disabled' : '';
+                        const card = `
+                            <div class="col-md-4">
+                                <div class="card h-100">
+                                    <div class="card-body d-flex flex-column">
+                                        <h5 class="card-title">${product.name}</h5>
+                                        <p class="text-muted flex-grow-1">${product.description || ''}</p>
+                                        <div class="d-flex justify-content-between align-items-center mt-2">
+                                            <span class="badge bg-success">₺${product.price}</span>
+                                            <button class="btn btn-primary btn-sm buy-product" data-id="${product.id}" ${disabled}>Satın Al</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>`;
+                        $quick.append(card);
+                    });
+                }
+            });
+    }
+
+    function fetchTickets() {
+        const $list = $('#ticket-list');
+        if (!$list.length) return;
+        $.getJSON(endpoints.tickets)
+            .done(function (response) {
+                $list.empty();
+                if (!response.tickets || !response.tickets.length) {
+                    $('#tickets-empty').removeClass('d-none');
+                    return;
+                }
+                $('#tickets-empty').addClass('d-none');
+                response.tickets.forEach(function (ticket) {
+                    const adminReply = ticket.admin_response ? `<div class="mt-2 p-3 bg-light border rounded"><strong>Yanıt:</strong><br>${ticket.admin_response}</div>` : '';
+                    const item = `
+                        <div class="list-group-item">
+                            <div class="d-flex justify-content-between">
+                                <h6 class="mb-1">${ticket.subject}</h6>
+                                <span class="ticket-status badge bg-${ticket.status === 'closed' ? 'secondary' : 'warning'}">${ticket.status_label}</span>
+                            </div>
+                            <div class="text-muted small">${ticket.created_at}</div>
+                            <p class="mb-2 mt-2">${ticket.message}</p>
+                            ${adminReply}
+                        </div>`;
+                    $list.append(item);
+                });
+            })
+            .fail(function () {
+                $('#tickets-empty').text('Ticketlar yüklenemedi.');
+            });
+    }
+
+    function showModal(title, body) {
+        let $modal = $('#globalModal');
+        if (!$modal.length) {
+            const modalHtml = `
+                <div class="modal fade" id="globalModal" tabindex="-1" aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title"></h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+                            </div>
+                            <div class="modal-body"></div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Tamam</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>`;
+            $('body').append(modalHtml);
+            $modal = $('#globalModal');
+        }
+        $modal.find('.modal-title').html(title);
+        $modal.find('.modal-body').html(body);
+        const modal = new bootstrap.Modal($modal[0]);
+        modal.show();
+    }
+
+    $(document).on('click', '.buy-product', function () {
+        const productId = $(this).data('id');
+        const $button = $(this);
+        $button.prop('disabled', true);
+        $.ajax({
+            url: endpoints.orderCreate,
+            method: 'POST',
+            data: {
+                product_id: productId,
+                csrf_token: CSRF_TOKEN
+            },
+            dataType: 'json'
+        }).done(function (response) {
+            if (response.success) {
+                showModal('Sipariş Oluşturuldu', `<p class="mb-2">Siparişiniz başarıyla oluşturuldu.</p><p class="mb-0"><strong>E-PIN:</strong> <code>${response.pin_code}</code></p>`);
+                fetchOrders();
+                fetchStats();
+            } else {
+                showModal('İşlem Başarısız', `<p>${response.message}</p>`);
+            }
+        }).fail(function () {
+            showModal('Hata', '<p>İşlem sırasında bir hata oluştu.</p>');
+        }).always(function () {
+            $button.prop('disabled', false);
+        });
+    });
+
+    $('#refresh-products').on('click', function () {
+        fetchProducts('#product-list');
+    });
+
+    $('#quick-refresh').on('click', function () {
+        fetchStats();
+    });
+
+    $('#orders-refresh').on('click', function () {
+        fetchOrders();
+    });
+
+    $('#tickets-refresh').on('click', function () {
+        fetchTickets();
+    });
+
+    $('#logout-link').on('click', function (e) {
+        e.preventDefault();
+        $.post(endpoints.logout, { csrf_token: CSRF_TOKEN }, function () {
+            window.location.href = '/epin_client/public/index.php';
+        }, 'json');
+    });
+
+    $('#login-form').on('submit', function (e) {
+        e.preventDefault();
+        const $error = $('#login-error');
+        clearAlert($error);
+        $.ajax({
+            url: endpoints.login,
+            method: 'POST',
+            data: $(this).serialize(),
+            dataType: 'json'
+        }).done(function (response) {
+            if (response.success) {
+                window.location.href = '/epin_client/public/dashboard.php';
+            } else {
+                handleError($error, response.message || 'Giriş başarısız.');
+            }
+        }).fail(function () {
+            handleError($error, 'Giriş sırasında hata oluştu.');
+        });
+    });
+
+    $('#register-form').on('submit', function (e) {
+        e.preventDefault();
+        const $error = $('#register-error');
+        clearAlert($error);
+        const password = $('#register-password').val();
+        const confirm = $('#register-password-confirm').val();
+        if (password !== confirm) {
+            return handleError($error, 'Şifreler eşleşmiyor.');
+        }
+        $.ajax({
+            url: endpoints.register,
+            method: 'POST',
+            data: $(this).serialize(),
+            dataType: 'json'
+        }).done(function (response) {
+            if (response.success) {
+                window.location.href = '/epin_client/public/dashboard.php';
+            } else {
+                handleError($error, response.message || 'Kayıt başarısız.');
+            }
+        }).fail(function () {
+            handleError($error, 'Kayıt sırasında hata oluştu.');
+        });
+    });
+
+    $('#payment-form').on('submit', function (e) {
+        e.preventDefault();
+        const $error = $('#payment-error');
+        const $success = $('#payment-success');
+        clearAlert($error);
+        clearAlert($success);
+        $.ajax({
+            url: endpoints.payment,
+            method: 'POST',
+            data: $(this).serialize(),
+            dataType: 'json'
+        }).done(function (response) {
+            if (response.success) {
+                $success.text(response.message).removeClass('d-none');
+                $('#amount').val('');
+                fetchStats();
+            } else {
+                handleError($error, response.message || 'İşlem başarısız.');
+            }
+        }).fail(function () {
+            handleError($error, 'Talebiniz alınamadı.');
+        });
+    });
+
+    $('#ticket-form').on('submit', function (e) {
+        e.preventDefault();
+        const $error = $('#ticket-error');
+        const $success = $('#ticket-success');
+        clearAlert($error);
+        clearAlert($success);
+        $.ajax({
+            url: endpoints.ticketCreate,
+            method: 'POST',
+            data: $(this).serialize(),
+            dataType: 'json'
+        }).done(function (response) {
+            if (response.success) {
+                $success.text('Ticket başarıyla oluşturuldu.').removeClass('d-none');
+                $('#ticket-form')[0].reset();
+                fetchTickets();
+            } else {
+                handleError($error, response.message || 'Ticket oluşturulamadı.');
+            }
+        }).fail(function () {
+            handleError($error, 'Ticket oluşturulurken hata oluştu.');
+        });
+    });
+
+    $('#profile-form').on('submit', function (e) {
+        e.preventDefault();
+        const $success = $('#profile-success');
+        const $error = $('#profile-error');
+        clearAlert($success);
+        clearAlert($error);
+        $.ajax({
+            url: endpoints.profileUpdate,
+            method: 'POST',
+            data: $(this).serialize(),
+            dataType: 'json'
+        }).done(function (response) {
+            if (response.success) {
+                $success.text('Profil bilgileriniz güncellendi.').removeClass('d-none');
+            } else {
+                handleError($error, response.message || 'Profil güncellenemedi.');
+            }
+        }).fail(function () {
+            handleError($error, 'Profil güncelleme sırasında hata oluştu.');
+        });
+    });
+
+    $('#password-form').on('submit', function (e) {
+        e.preventDefault();
+        const $success = $('#password-success');
+        const $error = $('#password-error');
+        clearAlert($success);
+        clearAlert($error);
+        const newPassword = $('#new-password').val();
+        const confirm = $('#new-password-confirm').val();
+        if (newPassword !== confirm) {
+            return handleError($error, 'Yeni şifreler eşleşmiyor.');
+        }
+        $.ajax({
+            url: endpoints.passwordUpdate,
+            method: 'POST',
+            data: $(this).serialize(),
+            dataType: 'json'
+        }).done(function (response) {
+            if (response.success) {
+                $success.text('Şifreniz güncellendi.').removeClass('d-none');
+                $('#password-form')[0].reset();
+            } else {
+                handleError($error, response.message || 'Şifre güncellenemedi.');
+            }
+        }).fail(function () {
+            handleError($error, 'Şifre güncelleme sırasında hata oluştu.');
+        });
+    });
+
+    // Initial loads
+    fetchProducts('#product-list');
+    fetchStats();
+    fetchOrders();
+    fetchTickets();
+})(jQuery);

--- a/epin_client/config.php
+++ b/epin_client/config.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+return [
+    'db' => [
+        'dsn' => 'mysql:host=127.0.0.1;dbname=epin;charset=utf8mb4',
+        'username' => 'root',
+        'password' => '',
+    ],
+    'session_name' => 'epin_customer',
+];

--- a/epin_client/includes/auth.php
+++ b/epin_client/includes/auth.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/helpers.php';
+require_once __DIR__ . '/csrf.php';
+
+function current_user(): ?array
+{
+    $userId = session_get('user_id');
+    if (!$userId) {
+        return null;
+    }
+
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT id, name, email, balance, created_at FROM users WHERE id = :id');
+    $stmt->execute(['id' => $userId]);
+    $user = $stmt->fetch();
+    return $user ?: null;
+}
+
+function is_authenticated(): bool
+{
+    return session_get('user_id') !== null;
+}
+
+function attempt_login(string $email, string $password): bool
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT id, password_hash FROM users WHERE email = :email');
+    $stmt->execute(['email' => $email]);
+    $user = $stmt->fetch();
+
+    if (!$user) {
+        return false;
+    }
+
+    if (!password_verify($password, $user['password_hash'])) {
+        return false;
+    }
+
+    session_regenerate_id(true);
+    session_set('user_id', (int)$user['id']);
+    return true;
+}
+
+function register_user(string $name, string $email, string $password): array
+{
+    $pdo = db();
+    $stmt = $pdo->prepare('SELECT id FROM users WHERE email = :email LIMIT 1');
+    $stmt->execute(['email' => $email]);
+    if ($stmt->fetch()) {
+        return ['success' => false, 'message' => 'Bu e-posta adresi zaten kayıtlı.'];
+    }
+
+    $passwordHash = password_hash($password, PASSWORD_BCRYPT);
+    $stmt = $pdo->prepare('INSERT INTO users (name, email, password_hash, balance, created_at) VALUES (:name, :email, :password_hash, 0, NOW())');
+    $stmt->execute([
+        'name' => $name,
+        'email' => $email,
+        'password_hash' => $passwordHash,
+    ]);
+
+    session_regenerate_id(true);
+    session_set('user_id', (int)$pdo->lastInsertId());
+
+    return ['success' => true];
+}
+
+function logout(): void
+{
+    session_forget('user_id');
+    session_regenerate_id(true);
+}

--- a/epin_client/includes/bootstrap.php
+++ b/epin_client/includes/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/session.php';
+require_once __DIR__ . '/helpers.php';
+require_once __DIR__ . '/csrf.php';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/auth.php';

--- a/epin_client/includes/csrf.php
+++ b/epin_client/includes/csrf.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/session.php';
+
+function csrf_token(): string
+{
+    $token = session_get('csrf_token');
+    if (!$token) {
+        $token = bin2hex(random_bytes(32));
+        session_set('csrf_token', $token);
+    }
+    return $token;
+}
+
+function verify_csrf(?string $token): bool
+{
+    if (!$token) {
+        return false;
+    }
+    $stored = session_get('csrf_token');
+    if (!$stored) {
+        return false;
+    }
+    return hash_equals($stored, $token);
+}

--- a/epin_client/includes/db.php
+++ b/epin_client/includes/db.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/session.php';
+
+$config = require __DIR__ . '/../config.php';
+
+function db(): PDO
+{
+    static $pdo = null;
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    global $config;
+
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ];
+
+    $pdo = new PDO(
+        $config['db']['dsn'],
+        $config['db']['username'],
+        $config['db']['password'],
+        $options
+    );
+
+    return $pdo;
+}

--- a/epin_client/includes/helpers.php
+++ b/epin_client/includes/helpers.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+function sanitize(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+function json_response(array $data, int $status = 200): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($data, JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function require_post(): void
+{
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        json_response(['error' => 'Invalid request method.'], 405);
+    }
+}
+
+function require_auth(): void
+{
+    if (!is_authenticated()) {
+        json_response(['error' => 'Unauthorized'], 401);
+    }
+}
+
+function redirect_if_not_authenticated(): void
+{
+    if (!is_authenticated()) {
+        header('Location: /epin_client/public/login.php');
+        exit;
+    }
+}
+
+function redirect_if_authenticated(): void
+{
+    if (is_authenticated()) {
+        header('Location: /epin_client/public/dashboard.php');
+        exit;
+    }
+}

--- a/epin_client/includes/session.php
+++ b/epin_client/includes/session.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+$config = require __DIR__ . '/../config.php';
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_name($config['session_name']);
+    session_set_cookie_params([
+        'lifetime' => 0,
+        'path' => '/',
+        'httponly' => true,
+        'samesite' => 'Lax',
+    ]);
+    session_start();
+}
+
+function session_get(string $key, mixed $default = null): mixed
+{
+    return $_SESSION[$key] ?? $default;
+}
+
+function session_set(string $key, mixed $value): void
+{
+    $_SESSION[$key] = $value;
+}
+
+function session_forget(string $key): void
+{
+    unset($_SESSION[$key]);
+}

--- a/epin_client/public/dashboard.php
+++ b/epin_client/public/dashboard.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/../includes/bootstrap.php';
+redirect_if_not_authenticated();
+$user = current_user();
+$title = 'Müşteri Paneli';
+require __DIR__ . '/partials/header.php';
+?>
+<div class="row g-4">
+    <div class="col-md-4">
+        <div class="card dashboard-card text-center">
+            <div class="card-body">
+                <div class="icon-circle bg-primary-subtle text-primary mb-3"><i class="fa-solid fa-wallet"></i></div>
+                <h5 class="card-title">Güncel Bakiye</h5>
+                <p class="display-6" id="balance-amount">₺<?= sanitize(number_format((float)$user['balance'], 2)) ?></p>
+                <a class="btn btn-outline-primary btn-sm" href="/epin_client/public/wallet.php">Bakiye Yükle</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card dashboard-card text-center">
+            <div class="card-body">
+                <div class="icon-circle bg-success-subtle text-success mb-3"><i class="fa-solid fa-cart-shopping"></i></div>
+                <h5 class="card-title">Toplam Sipariş</h5>
+                <p class="display-6" id="total-orders">-</p>
+                <a class="btn btn-outline-success btn-sm" href="/epin_client/public/orders.php">Siparişler</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card dashboard-card text-center">
+            <div class="card-body">
+                <div class="icon-circle bg-warning-subtle text-warning mb-3"><i class="fa-solid fa-ticket"></i></div>
+                <h5 class="card-title">Açık Ticket</h5>
+                <p class="display-6" id="open-tickets">-</p>
+                <a class="btn btn-outline-warning btn-sm" href="/epin_client/public/support.php">Destek</a>
+            </div>
+        </div>
+    </div>
+</div>
+<section class="mt-5">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="h5 mb-0">Hızlı Satın Alma</h2>
+        <button class="btn btn-sm btn-outline-primary" id="quick-refresh"><i class="fa-solid fa-rotate"></i> Yenile</button>
+    </div>
+    <div class="row g-3" id="quick-products"></div>
+</section>
+<?php require __DIR__ . '/partials/footer.php';

--- a/epin_client/public/index.php
+++ b/epin_client/public/index.php
@@ -1,0 +1,31 @@
+<?php
+$title = 'E-PIN Market - Ana Sayfa';
+require __DIR__ . '/partials/header.php';
+?>
+<div class="row mb-5 align-items-center">
+    <div class="col-lg-6">
+        <h1 class="display-5 fw-bold mb-3">Dijital Ürünler ve E-PIN Çözümleri</h1>
+        <p class="lead text-muted">Hızlı, güvenli ve anında teslimat. Favori oyunlarınız ve yazılımlarınız için kodları saniyeler içinde alın.</p>
+        <?php if (!is_authenticated()): ?>
+            <div class="d-flex gap-2">
+                <a href="/epin_client/public/register.php" class="btn btn-primary btn-lg"><i class="fa-solid fa-user-plus me-2"></i>Hemen Kayıt Ol</a>
+                <a href="/epin_client/public/login.php" class="btn btn-outline-light btn-lg"><i class="fa-solid fa-right-to-bracket me-2"></i>Giriş Yap</a>
+            </div>
+        <?php else: ?>
+            <a href="/epin_client/public/dashboard.php" class="btn btn-primary btn-lg"><i class="fa-solid fa-gauge me-2"></i>Panelime Git</a>
+        <?php endif; ?>
+    </div>
+    <div class="col-lg-6 text-center">
+        <img src="https://cdn.pixabay.com/photo/2016/12/13/22/40/code-1905226_1280.png" alt="E-PIN" class="img-fluid rounded-4 shadow" />
+    </div>
+</div>
+<section class="mb-5">
+    <div class="d-flex align-items-center justify-content-between mb-3">
+        <h2 class="h4 mb-0"><i class="fa-solid fa-store me-2 text-primary"></i>Popüler Ürünler</h2>
+        <?php if (is_authenticated()): ?>
+            <button class="btn btn-sm btn-outline-primary" id="refresh-products"><i class="fa-solid fa-rotate"></i> Yenile</button>
+        <?php endif; ?>
+    </div>
+    <div id="product-list" class="row g-4"></div>
+</section>
+<?php require __DIR__ . '/partials/footer.php';

--- a/epin_client/public/login.php
+++ b/epin_client/public/login.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../includes/bootstrap.php';
+redirect_if_authenticated();
+$title = 'Müşteri Girişi';
+require __DIR__ . '/partials/header.php';
+?>
+<div class="row justify-content-center">
+    <div class="col-lg-5">
+        <div class="card shadow-sm">
+            <div class="card-body p-4">
+                <h1 class="h4 text-center mb-4">Müşteri Paneline Giriş</h1>
+                <div class="alert alert-danger d-none" id="login-error"></div>
+                <form id="login-form" autocomplete="off">
+                    <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
+                    <div class="mb-3">
+                        <label for="login-email" class="form-label">E-posta</label>
+                        <input type="email" class="form-control" id="login-email" name="email" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="login-password" class="form-label">Şifre</label>
+                        <input type="password" class="form-control" id="login-password" name="password" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Giriş Yap</button>
+                </form>
+                <p class="text-center small mt-3">Hesabın yok mu? <a href="/epin_client/public/register.php">Hemen kayıt ol</a></p>
+            </div>
+        </div>
+    </div>
+</div>
+<?php require __DIR__ . '/partials/footer.php';

--- a/epin_client/public/logout.php
+++ b/epin_client/public/logout.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__ . '/../includes/bootstrap.php';
+logout();
+header('Location: /epin_client/public/index.php');
+exit;

--- a/epin_client/public/orders.php
+++ b/epin_client/public/orders.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/../includes/bootstrap.php';
+redirect_if_not_authenticated();
+$title = 'Siparişlerim';
+require __DIR__ . '/partials/header.php';
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h4 mb-1">Sipariş Geçmişi</h1>
+        <p class="text-muted mb-0">Tüm satın alımlarınız ve teslim edilen PIN kodları</p>
+    </div>
+    <button class="btn btn-outline-primary" id="orders-refresh"><i class="fa-solid fa-rotate"></i> Yenile</button>
+</div>
+<div class="card shadow-sm">
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table align-middle" id="orders-table">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Ürün</th>
+                        <th>Tarih</th>
+                        <th>Durum</th>
+                        <th>E-PIN</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+        <div class="text-center text-muted" id="orders-empty">Henüz siparişiniz bulunmuyor.</div>
+    </div>
+</div>
+<?php require __DIR__ . '/partials/footer.php';

--- a/epin_client/public/partials/footer.php
+++ b/epin_client/public/partials/footer.php
@@ -1,0 +1,13 @@
+    </div>
+</main>
+<footer class="bg-dark text-white py-4 mt-auto">
+    <div class="container text-center small">
+        &copy; <?= date('Y') ?> E-PIN Market - Tüm hakları saklıdır.
+    </div>
+</footer>
+<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-3fpdpA6arZz+Y3jACpShyp66gDJZH81PoYjF0A0Jw2E=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>const CSRF_TOKEN = '<?= csrf_token() ?>';</script>
+<script src="/epin_client/assets/js/app.js"></script>
+</body>
+</html>

--- a/epin_client/public/partials/header.php
+++ b/epin_client/public/partials/header.php
@@ -1,0 +1,40 @@
+<?php
+require_once __DIR__ . '/../../includes/bootstrap.php';
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= sanitize($title ?? 'E-PIN Platformu') ?></title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-MrUedvSY8DcpzMshflFMSo7EJ9j8F21Av9zCfnoFs5IunEzxZGCKMaAcW3XD2Le32cYE0C48SZ0pJr4MG5jV6g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="/epin_client/assets/css/app.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark shadow-sm">
+    <div class="container">
+        <a class="navbar-brand" href="/epin_client/public/index.php"><i class="fa-solid fa-bolt"></i> E-PIN Market</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Menu">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="mainNavbar">
+            <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+                <li class="nav-item"><a class="nav-link" href="/epin_client/public/index.php">Ana Sayfa</a></li>
+                <?php if (is_authenticated()): ?>
+                    <li class="nav-item"><a class="nav-link" href="/epin_client/public/dashboard.php">Panel</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/epin_client/public/orders.php">Siparişler</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/epin_client/public/wallet.php">Bakiye</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/epin_client/public/support.php">Destek</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/epin_client/public/profile.php">Profil</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#" id="logout-link">Çıkış</a></li>
+                <?php else: ?>
+                    <li class="nav-item"><a class="nav-link" href="/epin_client/public/login.php">Giriş</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/epin_client/public/register.php">Kayıt</a></li>
+                <?php endif; ?>
+            </ul>
+        </div>
+    </div>
+</nav>
+<main class="py-5">
+    <div class="container">

--- a/epin_client/public/profile.php
+++ b/epin_client/public/profile.php
@@ -1,0 +1,56 @@
+<?php
+require_once __DIR__ . '/../includes/bootstrap.php';
+redirect_if_not_authenticated();
+$user = current_user();
+$title = 'Profil Bilgileri';
+require __DIR__ . '/partials/header.php';
+?>
+<div class="row g-4">
+    <div class="col-lg-6">
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <h2 class="h5 mb-3">Kişisel Bilgiler</h2>
+                <div class="alert alert-success d-none" id="profile-success"></div>
+                <div class="alert alert-danger d-none" id="profile-error"></div>
+                <form id="profile-form">
+                    <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
+                    <div class="mb-3">
+                        <label for="profile-name" class="form-label">Ad Soyad</label>
+                        <input type="text" class="form-control" id="profile-name" name="name" value="<?= sanitize($user['name']) ?>" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="profile-email" class="form-label">E-posta</label>
+                        <input type="email" class="form-control" id="profile-email" name="email" value="<?= sanitize($user['email']) ?>" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Bilgileri Güncelle</button>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-6">
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <h2 class="h5 mb-3">Şifre Güncelle</h2>
+                <div class="alert alert-success d-none" id="password-success"></div>
+                <div class="alert alert-danger d-none" id="password-error"></div>
+                <form id="password-form">
+                    <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
+                    <div class="mb-3">
+                        <label for="current-password" class="form-label">Mevcut Şifre</label>
+                        <input type="password" class="form-control" id="current-password" name="current_password" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="new-password" class="form-label">Yeni Şifre</label>
+                        <input type="password" class="form-control" id="new-password" name="new_password" minlength="6" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="new-password-confirm" class="form-label">Yeni Şifre (Tekrar)</label>
+                        <input type="password" class="form-control" id="new-password-confirm" name="new_password_confirm" minlength="6" required>
+                    </div>
+                    <button type="submit" class="btn btn-outline-primary">Şifreyi Değiştir</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<?php require __DIR__ . '/partials/footer.php';

--- a/epin_client/public/register.php
+++ b/epin_client/public/register.php
@@ -1,0 +1,40 @@
+<?php
+require_once __DIR__ . '/../includes/bootstrap.php';
+redirect_if_authenticated();
+$title = 'Yeni Hesap Oluştur';
+require __DIR__ . '/partials/header.php';
+?>
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="card shadow-sm">
+            <div class="card-body p-4">
+                <h1 class="h4 text-center mb-4">Hızlıca hesabını oluştur</h1>
+                <div class="alert alert-danger d-none" id="register-error"></div>
+                <form id="register-form" autocomplete="off">
+                    <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label for="register-name" class="form-label">Ad Soyad</label>
+                            <input type="text" class="form-control" id="register-name" name="name" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="register-email" class="form-label">E-posta</label>
+                            <input type="email" class="form-control" id="register-email" name="email" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="register-password" class="form-label">Şifre</label>
+                            <input type="password" class="form-control" id="register-password" name="password" minlength="6" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="register-password-confirm" class="form-label">Şifre (Tekrar)</label>
+                            <input type="password" class="form-control" id="register-password-confirm" name="password_confirm" minlength="6" required>
+                        </div>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100 mt-3">Hesap Oluştur</button>
+                </form>
+                <p class="text-center small mt-3">Zaten hesabın var mı? <a href="/epin_client/public/login.php">Giriş yap</a></p>
+            </div>
+        </div>
+    </div>
+</div>
+<?php require __DIR__ . '/partials/footer.php';

--- a/epin_client/public/support.php
+++ b/epin_client/public/support.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__ . '/../includes/bootstrap.php';
+redirect_if_not_authenticated();
+$title = 'Destek Merkezi';
+require __DIR__ . '/partials/header.php';
+?>
+<div class="row g-4">
+    <div class="col-lg-5">
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <h2 class="h5 mb-3">Yeni Ticket Oluştur</h2>
+                <div class="alert alert-danger d-none" id="ticket-error"></div>
+                <div class="alert alert-success d-none" id="ticket-success"></div>
+                <form id="ticket-form">
+                    <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
+                    <div class="mb-3">
+                        <label for="ticket-subject" class="form-label">Konu</label>
+                        <input type="text" class="form-control" id="ticket-subject" name="subject" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="ticket-message" class="form-label">Mesajınız</label>
+                        <textarea class="form-control" id="ticket-message" name="message" rows="5" required></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Gönder</button>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-7">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h2 class="h5 mb-0">Ticket Geçmişi</h2>
+            <button class="btn btn-outline-primary btn-sm" id="tickets-refresh"><i class="fa-solid fa-rotate"></i> Yenile</button>
+        </div>
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <div class="list-group" id="ticket-list"></div>
+                <div class="text-center text-muted" id="tickets-empty">Henüz bir ticket açmadınız.</div>
+            </div>
+        </div>
+    </div>
+</div>
+<?php require __DIR__ . '/partials/footer.php';

--- a/epin_client/public/wallet.php
+++ b/epin_client/public/wallet.php
@@ -1,0 +1,43 @@
+<?php
+require_once __DIR__ . '/../includes/bootstrap.php';
+redirect_if_not_authenticated();
+$title = 'Bakiye Yönetimi';
+$user = current_user();
+require __DIR__ . '/partials/header.php';
+?>
+<div class="row g-4">
+    <div class="col-lg-6">
+        <div class="card shadow-sm h-100">
+            <div class="card-body">
+                <h1 class="h4 mb-3">Bakiye Durumu</h1>
+                <p class="display-5 text-primary">₺<?= sanitize(number_format((float)$user['balance'], 2)) ?></p>
+                <p class="text-muted">Bakiye yüklemeleri manuel olarak onaylanmaktadır. Aşağıdaki formu kullanarak talepte bulunun.</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-6">
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <h2 class="h5 mb-3">Bakiye Yükle</h2>
+                <div class="alert alert-danger d-none" id="payment-error"></div>
+                <div class="alert alert-success d-none" id="payment-success"></div>
+                <form id="payment-form">
+                    <input type="hidden" name="csrf_token" value="<?= csrf_token() ?>">
+                    <div class="mb-3">
+                        <label for="amount" class="form-label">Yükleme Tutarı (₺)</label>
+                        <input type="number" min="10" step="0.01" class="form-control" id="amount" name="amount" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="method" class="form-label">Ödeme Yöntemi</label>
+                        <select class="form-select" id="method" name="method">
+                            <option value="PayTR">PayTR (API placeholder)</option>
+                            <option value="Manuel">Manuel Havale/EFT</option>
+                        </select>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Talep Gönder</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<?php require __DIR__ . '/partials/footer.php';


### PR DESCRIPTION
## Summary
- add a standalone customer portal with Bootstrap 5 views for browsing products, managing orders, wallet, support tickets, and profile details
- wire up AJAX-driven flows for login, registration, purchasing E-PINs, balance top-ups, and ticket management without page reloads
- introduce reusable PHP helpers for secure sessions, CSRF tokens, and PDO access that back JSON APIs consumed by the UI

## Testing
- find epin_client -name "*.php" -print0 \| xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_b_68e1d1da64f48321b98cf806a8d23125