### PR TITLE
Add REST API v2 with SDKs and WooCommerce integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
-test
+# Reseller Script REST API
+
+Bu sürüm Reseller Script paneline REST mimarisinde çalışan, Swagger dokümantasyonlu ve SDK desteği olan yeni bir API katmanı ekler. API, ePin/lisans mağazanızı WordPress (WooCommerce) dâhil olmak üzere PHP, Node.js, Python gibi dillerle hızlıca entegre etmenizi sağlar.
+
+## 🚀 Özellikler
+
+- JSON tabanlı REST uç noktaları (`/api/v2`)
+- API anahtarı, Bearer Token veya HMAC imzalı güvenli istek desteği
+- IP beyaz liste, rate limit ve imzalı zaman damgası doğrulamaları
+- Swagger UI (`api/docs/index.html`), OpenAPI şeması (`api/openapi.yaml`) ve Postman koleksiyonu
+- PHP / Node.js / Python için hafif istemci kütüphaneleri (`integrations/sdk/`)
+- WooCommerce eklentisi ile ürün ve sipariş senkronizasyonu (`integrations/wordpress/reseller-api`)
+
+## 📦 Kurulum
+
+1. **Veritabanı**
+   - `schema.sql` dosyasındaki `api_tokens` alanlarının yeni sütunlara sahip olduğundan emin olun.
+   - Sistem otomatik olarak `src/Migrations/Schema.php` üzerinden şema güncellemesi yapacaktır.
+
+2. **Sunucu yapılandırması**
+   - PHP 8.1+, MySQL 5.7+ ve composer bağımlılıklarını kurun.
+   - Gerekirse `.env` veya `config/config.php` üzerinde veritabanı bilgilerinizi güncelleyin.
+
+3. **API erişimi**
+   - Yönetim panelinden bayi için API anahtarı oluşturun.
+   - Yeni anahtarlar otomatik olarak HMAC gizli anahtarı ile gelir. İmza doğrulaması yapmak istemiyorsanız boş bırakabilirsiniz.
+
+## 🔐 İstek Gönderme
+
+```bash
+curl -X POST "https://panel.example.com/api/v2/order/create" \
+  -H "X-API-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "product_id": 15,
+        "quantity": 1,
+        "external_reference": "EXT-1001"
+      }'
+```
+
+### HMAC İsteği
+
+```text
+signature = HMAC_SHA256(secret, timestamp + "\n" + METHOD + "\n" + PATH + "\n" + body)
+Headers:
+  X-API-Key: YOUR_API_KEY
+  X-Request-Timestamp: 1700000000
+  X-Signature: sha256=<hesaplanan-imza>
+```
+
+## 🧰 SDK Örnekleri
+
+- **PHP:** `integrations/sdk/php/ResellerApiClient.php`
+- **Node.js:** `integrations/sdk/node/index.js`
+- **Python:** `integrations/sdk/python/client.py`
+
+Her istemci `getProducts`, `createOrder`, `getOrderStatus`, `getBalance`, `getUserInfo` fonksiyonlarını içerir.
+
+## 🧩 WooCommerce Eklentisi
+
+`integrations/wordpress/reseller-api` klasörünü ZIP yaparak yönetim panelinden “Eklentiler → Yeni Ekle” üzerinden yükleyin.
+
+1. Ayarlar → WooCommerce → Reseller API menüsünden **API URL** ve **API Key** değerlerini girin.
+2. “WooCommerce Ürünlerini Güncelle” butonuyla paneldeki aktif ürünler WooCommerce’de sanal ürün olarak oluşturulur.
+3. WooCommerce siparişleri ödeme sonrası otomatik olarak Reseller API üzerinden oluşturulur ve durum bilgisi sipariş notu olarak eklenir.
+
+## 📚 Dokümantasyon
+
+- Swagger UI: `api/docs/index.html`
+- OpenAPI: `api/openapi.yaml`
+- Postman: `docs/postman/reseller-api.postman_collection.json`
+- Panel içi rehber: `/api-documentation.php`
+
+## 🧪 Test & Rate Limit
+
+- Varsayılan hız limiti dakikada 120 istektir. `api_tokens.rate_limit_per_minute` ile kullanıcı bazlı değer tanımlayabilirsiniz.
+- Tüm yanıtlar `meta.request_id` ve `meta.timestamp` alanları ile izlenebilir.
+
+## 🤝 Katkı
+
+Geliştirmeler için yeni uç noktalar eklerken `App\Api` katmanındaki controller ve servis mimarisini takip edin. Swagger şemasını güncellemeyi ve Postman koleksiyonuna yeni istekleri eklemeyi unutmayın.

--- a/api-documentation.php
+++ b/api-documentation.php
@@ -7,11 +7,13 @@ use App\Settings;
 
 Lang::boot();
 
-$pageTitle = 'API Dökümantasyonu';
-$metaDescription = 'Reseller paneliniz için sipariş, ürün ve webhook işlemlerini kapsayan REST API entegrasyon rehberi.';
-$baseUrl = Helpers::apiBaseUrl();
-$rateLimit = Settings::get('api_rate_limit_per_minute', 120);
-$rateLimit = $rateLimit ? (int)$rateLimit : 120;
+$pageTitle = 'REST API Dokümantasyonu';
+$metaDescription = 'Reseller Script için REST API uç noktaları, kimlik doğrulama, rate limit ve örnek entegrasyonlar.';
+$apiBase = rtrim(Helpers::apiBaseUrl(), '/') . '/v2';
+$rateLimit = (int) Settings::get('api_rate_limit_per_minute', 120);
+if ($rateLimit <= 0) {
+    $rateLimit = 120;
+}
 
 Helpers::includeTemplate('public-header.php', array(
     'pageTitle' => $pageTitle,
@@ -19,71 +21,111 @@ Helpers::includeTemplate('public-header.php', array(
 ));
 ?>
 
-<pre class="api-doc-code"><code>{
+<div class="page-container api-docs">
+    <section class="api-hero">
+        <h1>Reseller REST API</h1>
+        <p>Bayiler ve entegratörler için ürün listeleme, sipariş oluşturma ve bakiye yönetimi süreçlerini otomatikleştiren JSON tabanlı servis.</p>
+        <div class="hero-links">
+            <a class="btn" href="api/docs/index.html" target="_blank">Swagger Dokümanı</a>
+            <a class="btn" href="api/openapi.yaml" target="_blank">openapi.yaml</a>
+            <a class="btn" href="docs/postman/reseller-api.postman_collection.json" target="_blank">Postman Koleksiyonu</a>
+        </div>
+    </section>
+
+    <section class="api-card">
+        <h2>Kimlik Doğrulama</h2>
+        <ul>
+            <li><strong>X-API-Key</strong> başlığı veya <strong>Authorization: Bearer &lt;token&gt;</strong> kullanılabilir.</li>
+            <li>Opsiyonel HMAC kontrolü için <code>X-Request-Timestamp</code> (Unix epoch) ve <code>X-Signature</code> (sha256=&lt;imza&gt;) gönderilir.</li>
+            <li>İmza formülü: <code>HMAC_SHA256(secret, timestamp + "\n" + METHOD + "\n" + PATH + "\n" + body)</code></li>
+            <li>Varsayılan rate limit: dakikada <strong><?= (int) $rateLimit ?></strong> istek. Anahtar bazlı limit özelleştirilebilir.</li>
+        </ul>
+    </section>
+
+    <section class="api-card">
+        <h2>Temel Uç Noktalar</h2>
+        <table class="api-table">
+            <thead>
+            <tr>
+                <th>Method</th>
+                <th>Endpoint</th>
+                <th>Açıklama</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>GET</td>
+                <td><?= Helpers::sanitize($apiBase) ?>/products</td>
+                <td>Aktif ürünleri listeler.</td>
+            </tr>
+            <tr>
+                <td>POST</td>
+                <td><?= Helpers::sanitize($apiBase) ?>/order/create</td>
+                <td>Yeni sipariş oluşturur.</td>
+            </tr>
+            <tr>
+                <td>GET</td>
+                <td><?= Helpers::sanitize($apiBase) ?>/order/status</td>
+                <td>Sipariş durumunu sorgular.</td>
+            </tr>
+            <tr>
+                <td>GET</td>
+                <td><?= Helpers::sanitize($apiBase) ?>/balance</td>
+                <td>Kullanıcı bakiyesini getirir.</td>
+            </tr>
+            <tr>
+                <td>GET</td>
+                <td><?= Helpers::sanitize($apiBase) ?>/user/info</td>
+                <td>Bayi ve token meta verilerini döndürür.</td>
+            </tr>
+            </tbody>
+        </table>
+    </section>
+
+    <section class="api-card">
+        <h2>İstek Örnekleri</h2>
+        <h3>Ürün Listesi (cURL)</h3>
+        <pre><code class="language-bash">curl -X GET \
+  "<?= Helpers::sanitize($apiBase) ?>/products" \
+  -H "X-API-Key: YOUR_API_KEY"</code></pre>
+
+        <h3>Sipariş Oluşturma (PHP)</h3>
+        <pre><code class="language-php">$client = new Reseller\Sdk\ResellerApiClient('<?= Helpers::sanitize($apiBase) ?>', 'YOUR_API_KEY');
+$order = $client->createOrder([
+    'product_id' => 15,
+    'quantity' => 1,
+    'external_reference' => 'EXT-1001',
+]);</code></pre>
+
+        <h3>Sipariş Durumu (Node.js)</h3>
+        <pre><code class="language-javascript">import ResellerApiClient from './integrations/sdk/node/index.js';
+const client = new ResellerApiClient('<?= Helpers::sanitize($apiBase) ?>', process.env.API_KEY);
+const status = await client.getOrderStatus({ order_id: 42 });</code></pre>
+
+        <h3>Bakiye Sorgu (Python)</h3>
+        <pre><code class="language-python">from integrations.sdk.python.client import ResellerApiClient
+client = ResellerApiClient('<?= Helpers::sanitize($apiBase) ?>', api_key='YOUR_KEY', bearer_token='TOKEN')
+balance = client.get_balance()</code></pre>
+    </section>
+
+    <section class="api-card">
+        <h2>Yanıt Örneği</h2>
+        <pre><code class="language-json">{
   "success": true,
   "data": {
-    "reseller": {
-      "id": 12,
-      "name": "Demo Bayi",
-      "balance": 3500.5
-    },
-    "categories": [
-      {"id": 1, "name": "Oyun", "parent_id": null}
-    ],
-    "products": [
-      {
-        "id": 24,
-        "name": "Steam Cüzdan 100 TL",
-        "sku": "STM-100",
-
-      }
-    ]
-  }
-}</code></pre>
-
-<pre class="api-doc-code"><code>POST <?= Helpers::sanitize($baseUrl) ?>/orders
-Content-Type: application/json
-
-{
-  "order_id": "EXT-2024001",
-  "currency": "TRY",
-  "customer": {
-    "name": "Ahmet Yılmaz",
-    "email": "musteri@example.com"
+    "order_id": 4521,
+    "status": "pending",
+    "message": "Sipariş başarıyla oluşturuldu.",
+    "quantity": 1,
+    "total_amount": 89.9,
+    "remaining_balance": 310.1
   },
-  "items": [
-    {"sku": "STM-100", "quantity": 1, "note": "Hediye"}
-
-<pre class="api-doc-code"><code>{
-  "success": true,
-  "data": {
-    "orders": [4512],
-    "remaining_balance": 3120.60
+  "meta": {
+    "request_id": "c2341f4f7a2f4c1fb0195d54a7823c3f",
+    "timestamp": "<?= date('c') ?>"
   }
 }</code></pre>
+    </section>
+</div>
 
-<pre class="api-doc-code"><code>POST <?= Helpers::sanitize($baseUrl) ?>/token-webhook
-Content-Type: application/json
-
-{
-  "webhook_url": "https://entegrasyon.ornek.com/api/webhooks/reseller"
-}</code></pre>
-
-<pre class="api-doc-code"><code>{
-  "event": "order_status_changed",
-  "order_id": 4512,
-  "remote_order_id": 4512,
-  "status": "completed",
-  "previous_status": "processing",
-  "external_reference": "EXT-2024001",
-  "sku": "STM-100",
-  "quantity": 1,
-  "total": 89.90,
-  "admin_note": null,
-  "external_order": {
-    "id": "EXT-2024001",
-    "currency": "TRY",
-    "customer": {
-      "name": "Ahmet Yılmaz"
-    }
-
+<?php Helpers::includeTemplate('public-footer.php'); ?>

--- a/api/bootstrap.php
+++ b/api/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 header('Content-Type: application/json');
 
+$__apiRawBody = null;
+
 $autoloader = __DIR__ . '/../vendor/autoload.php';
 if (file_exists($autoloader)) {
     require_once $autoloader;
@@ -144,8 +146,8 @@ function json_response($data, $statusCode = 200)
 
 function read_json_body()
 {
-    $raw = file_get_contents('php://input');
-    if ($raw === false || $raw === '') {
+    $raw = api_raw_body();
+    if ($raw === '') {
         return array();
     }
 
@@ -155,6 +157,24 @@ function read_json_body()
     }
 
     return $decoded;
+}
+
+function api_raw_body(): string
+{
+    global $__apiRawBody;
+
+    if ($__apiRawBody !== null) {
+        return (string) $__apiRawBody;
+    }
+
+    $raw = file_get_contents('php://input');
+    if ($raw === false) {
+        $raw = '';
+    }
+
+    $__apiRawBody = $raw;
+
+    return $raw;
 }
 
 function authenticate_token()
@@ -253,9 +273,21 @@ function authenticate_token()
 
     try {
         App\Services\ApiSecurityService::guard($tokenRow, $__apiSecurityContext['ip'], $__apiSecurityContext['method'], $__apiSecurityContext['endpoint']);
+        App\Services\ApiSignatureService::assertValid($tokenRow, api_raw_body(), $__apiSecurityContext['method'], $__apiSecurityContext['endpoint']);
     } catch (\RuntimeException $securityException) {
-        App\Services\ApiSecurityService::logRequest($tokenRow, $__apiSecurityContext['ip'], $__apiSecurityContext['method'], $__apiSecurityContext['endpoint'], 429);
-        json_response(array('success' => false, 'error' => $securityException->getMessage()), 429);
+        $message = $securityException->getMessage();
+        $lowerMessage = strtolower($message);
+        $status = 403;
+
+        if (str_contains($lowerMessage, 'rate limit')) {
+            $status = 429;
+            $__apiSecurityContext['retry_after'] = 60;
+        } elseif (str_contains($lowerMessage, 'imza') || str_contains($lowerMessage, 'otp')) {
+            $status = 401;
+        }
+
+        App\Services\ApiSecurityService::logRequest($tokenRow, $__apiSecurityContext['ip'], $__apiSecurityContext['method'], $__apiSecurityContext['endpoint'], $status);
+        json_response(array('success' => false, 'error' => $message), $status);
     }
 
     return $tokenRow;

--- a/api/docs/index.html
+++ b/api/docs/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="utf-8">
+    <title>Reseller REST API Dokümantasyonu</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.11.0/swagger-ui.css">
+    <style>
+        body { margin: 0; font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0f172a; }
+        header { background: #111827; color: #f8fafc; padding: 32px 48px; }
+        header h1 { margin: 0; font-size: 28px; }
+        header p { margin: 8px 0 0; color: #cbd5f5; max-width: 760px; }
+        main { display: flex; flex-direction: column; min-height: 100vh; }
+        section.guide { background: #020617; color: #e2e8f0; padding: 32px 48px; border-bottom: 1px solid rgba(148, 163, 184, 0.2); }
+        section.guide h2 { margin-top: 0; font-size: 20px; }
+        section.guide pre { background: #0f172a; color: #e2e8f0; padding: 16px; border-radius: 8px; overflow-x: auto; }
+        #swagger-ui { flex: 1; background: #fff; }
+        a { color: #38bdf8; }
+        .columns { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 24px; }
+        .card { background: rgba(148, 163, 184, 0.08); padding: 20px; border-radius: 12px; }
+        .card h3 { margin-top: 0; font-size: 18px; }
+    </style>
+</head>
+<body>
+<main>
+    <header>
+        <h1>Reseller REST API</h1>
+        <p>Bayileriniz için ürün listeleme, sipariş oluşturma ve bakiye yönetimi işlemlerini otomatikleştiren REST servisi.
+            Bu sayfa <code>api/openapi.yaml</code> dosyasından üretilen Swagger dokümantasyonunu içermektedir.</p>
+    </header>
+    <section class="guide">
+        <h2>Başlangıç</h2>
+        <div class="columns">
+            <div class="card">
+                <h3>Kimlik Doğrulama</h3>
+                <p>İsteklerinize <code>X-API-Key</code> başlığı veya <code>Authorization: Bearer &lt;token&gt;</code> formatında
+                    kimlik bilgisi ekleyin. HMAC imzası aktifleştirilen anahtarlar için aşağıdaki formülü kullanın:</p>
+                <pre>signature = HMAC_SHA256(secret, timestamp + "\n" + METHOD + "\n" + PATH + "\n" + body)
+X-Request-Timestamp: &lt;unix epoch&gt;
+X-Signature: sha256=&lt;signature&gt;</pre>
+            </div>
+            <div class="card">
+                <h3>Hız Limiti</h3>
+                <p>Varsayılan limit dakika başına 120 istektir. API anahtarı bazında farklı sınırlar tanımlanabilir.</p>
+            </div>
+            <div class="card">
+                <h3>Doküman Dosyaları</h3>
+                <ul>
+                    <li><a href="../openapi.yaml">openapi.yaml</a></li>
+                    <li><a href="../../docs/postman/reseller-api.postman_collection.json">Postman koleksiyonu</a></li>
+                </ul>
+            </div>
+        </div>
+    </section>
+    <div id="swagger-ui"></div>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.11.0/swagger-ui-bundle.js"></script>
+<script>
+window.addEventListener('load', () => {
+  SwaggerUIBundle({
+    url: '../openapi.yaml',
+    dom_id: '#swagger-ui',
+    presets: [SwaggerUIBundle.presets.apis],
+    layout: 'BaseLayout'
+  });
+});
+</script>
+</body>
+</html>

--- a/api/index.php
+++ b/api/index.php
@@ -2,5 +2,9 @@
 require __DIR__ . '/bootstrap.php';
 
 json_response(array(
-    'message' => 'Reseller API. Use /api/v1/products and /api/v1/orders for REST access.'
+    'message' => 'Reseller API hazır. Güncel REST uç noktaları için /api/v2 yolunu kullanın.',
+    'links' => array(
+        'openapi' => '/api/openapi.yaml',
+        'documentation' => '/api/docs/index.html',
+    ),
 ));

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,291 @@
+openapi: 3.0.3
+info:
+  title: Reseller REST API
+  version: 2.0.0
+  description: |
+    Reseller Script için REST tabanlı bayi API'si.
+servers:
+  - url: https://example.com/api/v2
+    description: Production
+  - url: https://sandbox.example.com/api/v2
+    description: Sandbox
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Token
+  schemas:
+    Product:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        sku:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        price:
+          type: number
+          format: float
+        status:
+          type: string
+        automatic_delivery:
+          type: boolean
+        provider_code:
+          type: string
+          nullable: true
+        provider_product_id:
+          type: string
+          nullable: true
+        category:
+          type: object
+          properties:
+            id:
+              type: integer
+              nullable: true
+            name:
+              type: string
+              nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+    OrderCreateRequest:
+      type: object
+      required:
+        - product_id
+      properties:
+        product_id:
+          type: integer
+        sku:
+          type: string
+          description: Product SKU yerine ID göndermek için kullanılabilir.
+        quantity:
+          type: integer
+          minimum: 1
+          default: 1
+        note:
+          type: string
+        external_reference:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: true
+      example:
+        product_id: 15
+        quantity: 1
+        note: "Otomatik teslimat"
+        external_reference: "EXT-12345"
+        metadata:
+          customer:
+            email: customer@example.com
+    OrderResponse:
+      type: object
+      properties:
+        order_id:
+          type: integer
+        status:
+          type: string
+        message:
+          type: string
+        product:
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
+            sku:
+              type: string
+              nullable: true
+        quantity:
+          type: integer
+        total_amount:
+          type: number
+        remaining_balance:
+          type: number
+        provider_note:
+          type: string
+          nullable: true
+        delivery:
+          type: string
+          nullable: true
+    Order:
+      allOf:
+        - $ref: '#/components/schemas/OrderResponse'
+        - type: object
+          properties:
+            admin_note:
+              type: string
+              nullable: true
+            external_reference:
+              type: string
+              nullable: true
+            metadata:
+              type: object
+              additionalProperties: true
+            created_at:
+              type: string
+              format: date-time
+            updated_at:
+              type: string
+              format: date-time
+paths:
+  /products:
+    get:
+      summary: Aktif ürünleri listeler.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Ürün listesi.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      products:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Product'
+                      count:
+                        type: integer
+  /order/create:
+    post:
+      summary: Yeni ürün siparişi oluşturur.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderCreateRequest'
+      responses:
+        '201':
+          description: Sipariş oluşturuldu.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/OrderResponse'
+        '422':
+          description: Doğrulama hatası.
+  /order/status:
+    get:
+      summary: Sipariş durumunu döndürür.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - in: query
+          name: order_id
+          schema:
+            type: integer
+        - in: query
+          name: external_reference
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Sipariş bulundu.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      order:
+                        $ref: '#/components/schemas/Order'
+        '404':
+          description: Sipariş bulunamadı.
+  /balance:
+    get:
+      summary: Kullanıcı bakiyesini döndürür.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Bakiye bilgisi.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      balance:
+                        type: number
+                      currency:
+                        type: string
+                      updated_at:
+                        type: string
+                        format: date-time
+  /user/info:
+    get:
+      summary: Bayi ve token bilgilerini döndürür.
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Kullanıcı bilgisi.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      user:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                          name:
+                            type: string
+                          email:
+                            type: string
+                          balance:
+                            type: number
+                          role:
+                            type: string
+                      token:
+                        type: object
+                        properties:
+                          token_id:
+                            type: integer
+                            nullable: true
+                          label:
+                            type: string
+                            nullable: true
+                          scopes:
+                            type: string
+                            nullable: true
+                          ip_whitelist:
+                            type: string
+                            nullable: true
+                          rate_limit_per_minute:
+                            type: integer
+                            nullable: true

--- a/api/v2/index.php
+++ b/api/v2/index.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+use App\Api\Controllers\BalanceController;
+use App\Api\Controllers\OrderController;
+use App\Api\Controllers\ProductController;
+use App\Api\Controllers\UserController;
+use App\Api\Http\Request;
+use App\Api\Routing\Router;
+
+$request = Request::fromGlobals('/api/v2');
+$router = new Router('/api/v2');
+
+$router->get('/', function () {
+    return array(
+        'data' => array(
+            'name' => 'Reseller REST API',
+            'version' => '2.0.0',
+        ),
+    );
+});
+
+$router->get('/products', function (Request $request) {
+    $token = authenticate_token();
+    require_scope($token, 'products:read');
+    $request->setToken($token);
+
+    $controller = new ProductController();
+    return $controller->index($request);
+});
+
+$router->post('/order/create', function (Request $request) {
+    $token = authenticate_token();
+    require_scope($token, 'orders:write');
+    $request->setToken($token);
+
+    $controller = new OrderController();
+    return $controller->create($request);
+});
+
+$router->get('/order/status', function (Request $request) {
+    $token = authenticate_token();
+    require_scope($token, 'orders:read');
+    $request->setToken($token);
+
+    $controller = new OrderController();
+    return $controller->status($request);
+});
+
+$router->get('/balance', function (Request $request) {
+    $token = authenticate_token();
+    require_scope($token, 'balance:read');
+    $request->setToken($token);
+
+    $controller = new BalanceController();
+    return $controller->show($request);
+});
+
+$router->get('/user/info', function (Request $request) {
+    $token = authenticate_token();
+    require_scope($token, 'user:read');
+    $request->setToken($token);
+
+    $controller = new UserController();
+    return $controller->info($request);
+});
+
+$router->dispatch($request);

--- a/app/ApiToken.php
+++ b/app/ApiToken.php
@@ -18,7 +18,7 @@ class ApiToken
         }
 
         $pdo = Database::connection();
-        $query = 'SELECT t.id AS token_id, t.user_id, t.token, t.label, t.webhook_url, t.status AS token_status, t.scopes, t.ip_whitelist, t.otp_secret, t.created_at AS token_created_at, t.last_used_at, u.id AS user_id, u.name, u.email, u.balance, u.role, u.status, u.created_at, u.updated_at FROM api_tokens t INNER JOIN users u ON t.user_id = u.id WHERE t.token = :token AND u.status = :status AND t.status = :token_status';
+        $query = 'SELECT t.id AS token_id, t.user_id, t.token, t.label, t.webhook_url, t.status AS token_status, t.scopes, t.ip_whitelist, t.otp_secret, t.hmac_secret, t.rate_limit_per_minute, t.created_at AS token_created_at, t.last_used_at, u.id AS user_id, u.name, u.email, u.balance, u.role, u.status, u.created_at, u.updated_at FROM api_tokens t INNER JOIN users u ON t.user_id = u.id WHERE t.token = :token AND u.status = :status AND t.status = :token_status';
         $params = array(
             'token' => $token,
             'status' => 'active',
@@ -51,6 +51,8 @@ class ApiToken
                 'scopes' => isset($row['scopes']) ? (string)$row['scopes'] : '',
                 'ip_whitelist' => isset($row['ip_whitelist']) ? (string)$row['ip_whitelist'] : '',
                 'otp_secret' => isset($row['otp_secret']) ? (string)$row['otp_secret'] : '',
+                'hmac_secret' => isset($row['hmac_secret']) ? (string)$row['hmac_secret'] : '',
+                'rate_limit_per_minute' => isset($row['rate_limit_per_minute']) ? (int)$row['rate_limit_per_minute'] : null,
                 'created_at' => isset($row['token_created_at']) ? $row['token_created_at'] : null,
                 'last_used_at' => isset($row['last_used_at']) ? $row['last_used_at'] : null,
                 'name' => isset($row['name']) ? $row['name'] : null,
@@ -77,13 +79,16 @@ class ApiToken
     {
         $plain = bin2hex(random_bytes(16));
         $pdo = Database::connection();
-        $stmt = $pdo->prepare('INSERT INTO api_tokens (user_id, token, label, scopes, status, created_at) VALUES (:user_id, :token, :label, :scopes, :status, NOW())');
+        $hmacSecret = bin2hex(random_bytes(32));
+
+        $stmt = $pdo->prepare('INSERT INTO api_tokens (user_id, token, label, scopes, status, hmac_secret, created_at) VALUES (:user_id, :token, :label, :scopes, :status, :hmac_secret, NOW())');
         $stmt->execute(array(
             'user_id' => $userId,
             'token' => $plain,
             'label' => $label,
             'scopes' => is_array($scopes) ? implode(',', $scopes) : (string)$scopes,
             'status' => 'active',
+            'hmac_secret' => $hmacSecret,
         ));
 
         return array(
@@ -93,6 +98,7 @@ class ApiToken
             'label' => $label,
             'webhook_url' => null,
             'scopes' => is_array($scopes) ? implode(',', $scopes) : (string)$scopes,
+            'hmac_secret' => $hmacSecret,
             'created_at' => date('Y-m-d H:i:s'),
             'last_used_at' => null,
         );
@@ -347,6 +353,7 @@ class ApiToken
                 'token' => $existing['token'],
                 'label' => isset($existing['label']) ? $existing['label'] : null,
                 'webhook_url' => isset($existing['webhook_url']) ? $existing['webhook_url'] : null,
+                'hmac_secret' => isset($existing['hmac_secret']) ? $existing['hmac_secret'] : null,
                 'created_at' => isset($existing['created_at']) ? $existing['created_at'] : null,
                 'last_used_at' => isset($existing['last_used_at']) ? $existing['last_used_at'] : null,
             );

--- a/app/Services/ApiSecurityService.php
+++ b/app/Services/ApiSecurityService.php
@@ -184,7 +184,8 @@ class ApiSecurityService
      */
     private static function checkRateLimit(array $tokenRow, string $ip, string $method, string $endpoint): void
     {
-        $limitPerMinute = (int)Settings::get('api_rate_limit_per_minute');
+        $limitOverride = isset($tokenRow['rate_limit_per_minute']) ? (int) $tokenRow['rate_limit_per_minute'] : 0;
+        $limitPerMinute = $limitOverride > 0 ? $limitOverride : (int) Settings::get('api_rate_limit_per_minute');
         if ($limitPerMinute <= 0) {
             $limitPerMinute = 120;
         }

--- a/app/Services/ApiSignatureService.php
+++ b/app/Services/ApiSignatureService.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace App\Services;
+
+use RuntimeException;
+
+/**
+ * API istekleri için opsiyonel HMAC doğrulama kontrollerini gerçekleştirir.
+ */
+final class ApiSignatureService
+{
+    /**
+     * Validate the optional HMAC signature headers for the API request.
+     *
+     * @param array<string,mixed> $tokenRow
+     * @param string $rawBody
+     * @param string $method
+     * @param string $endpoint
+     */
+    public static function assertValid(array $tokenRow, string $rawBody, string $method, string $endpoint): void
+    {
+        $secret = isset($tokenRow['hmac_secret']) ? trim((string) $tokenRow['hmac_secret']) : '';
+        if ($secret === '') {
+            return; // HMAC zorunlu değil.
+        }
+
+        $timestamp = self::readHeader('HTTP_X_REQUEST_TIMESTAMP');
+        if ($timestamp === null) {
+            $timestamp = self::readHeader('HTTP_X_TIMESTAMP');
+        }
+        if ($timestamp === null) {
+            throw new RuntimeException('HMAC doğrulaması için zaman damgası bulunamadı.');
+        }
+
+        if (!ctype_digit($timestamp)) {
+            throw new RuntimeException('Geçersiz zaman damgası değeri.');
+        }
+
+        $requestTime = (int) $timestamp;
+        $now = time();
+        if (abs($now - $requestTime) > 300) {
+            throw new RuntimeException('İmza zaman aşımına uğradı.');
+        }
+
+        $signature = self::readHeader('HTTP_X_SIGNATURE');
+        if ($signature === null) {
+            $signature = self::readHeader('HTTP_X_HMAC_SIGNATURE');
+        }
+        if ($signature === null) {
+            throw new RuntimeException('HMAC imzası bulunamadı.');
+        }
+
+        $signature = trim($signature);
+        if ($signature === '') {
+            throw new RuntimeException('HMAC imzası bulunamadı.');
+        }
+
+        $hash = $signature;
+        if (stripos($hash, 'sha256=') === 0) {
+            $hash = substr($hash, 7);
+        }
+
+        if (!preg_match('/^[A-Fa-f0-9]{64}$/', $hash)) {
+            throw new RuntimeException('HMAC imza formatı geçersiz.');
+        }
+
+        $payload = $requestTime . "\n" . strtoupper($method) . "\n" . $endpoint . "\n" . $rawBody;
+        $computed = hash_hmac('sha256', $payload, $secret);
+
+        if (!hash_equals($computed, strtolower($hash))) {
+            throw new RuntimeException('HMAC imzası doğrulanamadı.');
+        }
+    }
+
+    private static function readHeader(string $name): ?string
+    {
+        return isset($_SERVER[$name]) ? (string) $_SERVER[$name] : null;
+    }
+}

--- a/docs/postman/reseller-api.postman_collection.json
+++ b/docs/postman/reseller-api.postman_collection.json
@@ -1,0 +1,93 @@
+{
+  "info": {
+    "name": "Reseller REST API",
+    "description": "Reseller Script için REST API uç noktaları",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "version": "2.0.0"
+  },
+  "item": [
+    {
+      "name": "List Products",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "X-API-Key", "value": "{{api_key}}" }
+        ],
+        "url": {
+          "raw": "{{base_url}}/products",
+          "host": [ "{{base_url}}" ],
+          "path": [ "products" ]
+        }
+      }
+    },
+    {
+      "name": "Create Order",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "X-API-Key", "value": "{{api_key}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"product_id\": 15,\n  \"quantity\": 1,\n  \"external_reference\": \"EXT-123\"\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/order/create",
+          "host": [ "{{base_url}}" ],
+          "path": [ "order", "create" ]
+        }
+      }
+    },
+    {
+      "name": "Order Status",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "X-API-Key", "value": "{{api_key}}" }
+        ],
+        "url": {
+          "raw": "{{base_url}}/order/status?order_id=123",
+          "host": [ "{{base_url}}" ],
+          "path": [ "order", "status" ],
+          "query": [
+            { "key": "order_id", "value": "123" }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Get Balance",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Authorization", "value": "Bearer {{token}}" }
+        ],
+        "url": {
+          "raw": "{{base_url}}/balance",
+          "host": [ "{{base_url}}" ],
+          "path": [ "balance" ]
+        }
+      }
+    },
+    {
+      "name": "User Info",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Authorization", "value": "Bearer {{token}}" }
+        ],
+        "url": {
+          "raw": "{{base_url}}/user/info",
+          "host": [ "{{base_url}}" ],
+          "path": [ "user", "info" ]
+        }
+      }
+    }
+  ],
+  "variable": [
+    { "key": "base_url", "value": "https://example.com/api/v2" },
+    { "key": "api_key", "value": "" },
+    { "key": "token", "value": "" }
+  ]
+}

--- a/integrations/sdk/node/index.js
+++ b/integrations/sdk/node/index.js
@@ -1,0 +1,91 @@
+import crypto from 'node:crypto';
+import https from 'node:https';
+
+/**
+ * Minimal Node.js istemcisi. Node 18+ üzerinde çalışır.
+ */
+export default class ResellerApiClient {
+  /**
+   * @param {string} baseUrl
+   * @param {string} apiKey
+   * @param {{bearerToken?: string, hmacSecret?: string}} [options]
+   */
+  constructor(baseUrl, apiKey, options = {}) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.apiKey = apiKey;
+    this.bearerToken = options.bearerToken ?? null;
+    this.hmacSecret = options.hmacSecret ?? null;
+    this.httpAgent = new https.Agent({ keepAlive: true });
+  }
+
+  async getProducts() {
+    const response = await this.request('GET', '/products');
+    return response.data?.products ?? [];
+  }
+
+  async createOrder(payload) {
+    const response = await this.request('POST', '/order/create', payload);
+    return response.data ?? {};
+  }
+
+  async getOrderStatus(query) {
+    const response = await this.request('GET', '/order/status', null, query);
+    return response.data?.order ?? {};
+  }
+
+  async getBalance() {
+    const response = await this.request('GET', '/balance');
+    return response.data ?? {};
+  }
+
+  async getUserInfo() {
+    const response = await this.request('GET', '/user/info');
+    return response.data ?? {};
+  }
+
+  async request(method, path, body = null, query = undefined) {
+    let url = `${this.baseUrl}${path}`;
+    if (query && Object.keys(query).length > 0) {
+      const params = new URLSearchParams(query);
+      url += `?${params.toString()}`;
+    }
+
+    const headers = {
+      'Accept': 'application/json',
+      'X-API-Key': this.apiKey,
+    };
+
+    let payload = undefined;
+    if (body !== null && body !== undefined) {
+      payload = JSON.stringify(body);
+      headers['Content-Type'] = 'application/json';
+    }
+
+    if (this.bearerToken) {
+      headers['Authorization'] = `Bearer ${this.bearerToken}`;
+    }
+
+    if (this.hmacSecret) {
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const signingPayload = `${timestamp}\n${method.toUpperCase()}\n${path}\n${payload ?? ''}`;
+      const signature = crypto.createHmac('sha256', this.hmacSecret).update(signingPayload).digest('hex');
+      headers['X-Request-Timestamp'] = timestamp;
+      headers['X-Signature'] = `sha256=${signature}`;
+    }
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: payload,
+      agent: this.httpAgent,
+    });
+
+    const json = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const message = json?.error ?? `API error (${response.status})`;
+      throw new Error(message);
+    }
+
+    return json;
+  }
+}

--- a/integrations/sdk/php/ResellerApiClient.php
+++ b/integrations/sdk/php/ResellerApiClient.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+namespace Reseller\Sdk;
+
+use RuntimeException;
+
+class ResellerApiClient
+{
+    private string $baseUrl;
+    private string $apiKey;
+    private ?string $bearerToken;
+    private ?string $hmacSecret;
+
+    public function __construct(string $baseUrl, string $apiKey, ?string $bearerToken = null, ?string $hmacSecret = null)
+    {
+        $this->baseUrl = rtrim($baseUrl, '/');
+        $this->apiKey = $apiKey;
+        $this->bearerToken = $bearerToken;
+        $this->hmacSecret = $hmacSecret;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function getProducts(): array
+    {
+        $response = $this->request('GET', '/products');
+        return $response['data']['products'] ?? array();
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>
+     */
+    public function createOrder(array $payload): array
+    {
+        $response = $this->request('POST', '/order/create', $payload);
+        return $response['data'] ?? array();
+    }
+
+    /**
+     * @param array<string,string|int> $query
+     * @return array<string,mixed>
+     */
+    public function getOrderStatus(array $query): array
+    {
+        $response = $this->request('GET', '/order/status', null, $query);
+        return $response['data']['order'] ?? array();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getBalance(): array
+    {
+        $response = $this->request('GET', '/balance');
+        return $response['data'] ?? array();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getUserInfo(): array
+    {
+        $response = $this->request('GET', '/user/info');
+        return $response['data'] ?? array();
+    }
+
+    /**
+     * @param array<string,mixed>|null $body
+     * @param array<string,mixed> $query
+     * @return array<string,mixed>
+     */
+    private function request(string $method, string $path, ?array $body = null, array $query = array()): array
+    {
+        $url = $this->baseUrl . $path;
+        if ($query) {
+            $url .= '?' . http_build_query($query);
+        }
+
+        $headers = array(
+            'Accept: application/json',
+            'X-API-Key: ' . $this->apiKey,
+        );
+
+        $payload = '';
+        if ($body !== null) {
+            $payload = json_encode($body, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            if ($payload === false) {
+                throw new RuntimeException('Gönderilecek JSON içeriği hazırlanamadı.');
+            }
+            $headers[] = 'Content-Type: application/json';
+        }
+
+        if ($this->bearerToken !== null && $this->bearerToken !== '') {
+            $headers[] = 'Authorization: Bearer ' . $this->bearerToken;
+        }
+
+        if ($this->hmacSecret) {
+            $timestamp = (string) time();
+            $signaturePayload = $timestamp . "\n" . strtoupper($method) . "\n" . $path . "\n" . $payload;
+            $signature = hash_hmac('sha256', $signaturePayload, $this->hmacSecret);
+            $headers[] = 'X-Request-Timestamp: ' . $timestamp;
+            $headers[] = 'X-Signature: sha256=' . $signature;
+        }
+
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+
+        if ($payload !== '') {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+        }
+
+        $responseBody = curl_exec($ch);
+        $statusCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        if ($responseBody === false) {
+            $error = curl_error($ch);
+            curl_close($ch);
+            throw new RuntimeException('API isteği gönderilemedi: ' . $error);
+        }
+
+        curl_close($ch);
+
+        $decoded = json_decode($responseBody, true);
+        if (!is_array($decoded)) {
+            throw new RuntimeException('API yanıtı çözümlenemedi.');
+        }
+
+        if ($statusCode >= 400) {
+            $message = isset($decoded['error']) ? (string) $decoded['error'] : 'API hatası oluştu.';
+            throw new RuntimeException(sprintf('API hatası (%d): %s', $statusCode, $message));
+        }
+
+        return $decoded;
+    }
+}

--- a/integrations/sdk/python/client.py
+++ b/integrations/sdk/python/client.py
@@ -1,0 +1,90 @@
+"""Reseller REST API için hafif Python istemcisi."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class ResellerApiClient:
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        bearer_token: Optional[str] = None,
+        hmac_secret: Optional[str] = None,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip('/')
+        self.api_key = api_key
+        self.bearer_token = bearer_token
+        self.hmac_secret = hmac_secret
+        self.session = session or requests.Session()
+
+    def get_products(self) -> Any:
+        response = self._request('GET', '/products')
+        return response.get('data', {}).get('products', [])
+
+    def create_order(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        response = self._request('POST', '/order/create', json_body=payload)
+        return response.get('data', {})
+
+    def get_order_status(self, **params: Any) -> Dict[str, Any]:
+        response = self._request('GET', '/order/status', params=params)
+        return response.get('data', {}).get('order', {})
+
+    def get_balance(self) -> Dict[str, Any]:
+        response = self._request('GET', '/balance')
+        return response.get('data', {})
+
+    def get_user_info(self) -> Dict[str, Any]:
+        response = self._request('GET', '/user/info')
+        return response.get('data', {})
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        json_body: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        headers = {
+            'Accept': 'application/json',
+            'X-API-Key': self.api_key,
+        }
+
+        body = json.dumps(json_body, ensure_ascii=False) if json_body is not None else ''
+        data_to_send = body if body else None
+
+        if data_to_send is not None:
+            headers['Content-Type'] = 'application/json'
+
+        if self.bearer_token:
+            headers['Authorization'] = f'Bearer {self.bearer_token}'
+
+        if self.hmac_secret:
+            timestamp = str(int(time.time()))
+            signature_payload = f"{timestamp}\n{method.upper()}\n{path}\n{body}"
+            signature = hmac.new(
+                self.hmac_secret.encode('utf-8'),
+                signature_payload.encode('utf-8'),
+                hashlib.sha256,
+            ).hexdigest()
+            headers['X-Request-Timestamp'] = timestamp
+            headers['X-Signature'] = f'sha256={signature}'
+
+        response = self.session.request(
+            method=method,
+            url=url,
+            headers=headers,
+            data=data_to_send,
+            params=params,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/integrations/wordpress/reseller-api/includes/class-rs-api-client.php
+++ b/integrations/wordpress/reseller-api/includes/class-rs-api-client.php
@@ -1,0 +1,80 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class RS_Api_Client
+{
+    private function get_base_url(): string
+    {
+        $url = (string) get_option(RS_Api_Bridge::OPTION_URL, '');
+        return rtrim($url, '/');
+    }
+
+    private function get_headers(): array
+    {
+        $headers = array('Accept' => 'application/json');
+        $apiKey = (string) get_option(RS_Api_Bridge::OPTION_KEY, '');
+        if ($apiKey !== '') {
+            $headers['X-API-Key'] = $apiKey;
+        }
+
+        return $headers;
+    }
+
+    public function get_products()
+    {
+        $url = $this->get_base_url() . '/products';
+        $response = wp_remote_get($url, array(
+            'headers' => $this->get_headers(),
+            'timeout' => 20,
+        ));
+
+        return $this->parse_response($response);
+    }
+
+    public function create_order(array $payload)
+    {
+        $url = $this->get_base_url() . '/order/create';
+        $response = wp_remote_post($url, array(
+            'headers' => array_merge($this->get_headers(), array('Content-Type' => 'application/json')),
+            'body' => wp_json_encode($payload),
+            'timeout' => 20,
+        ));
+
+        return $this->parse_response($response);
+    }
+
+    public function get_order_status(array $query)
+    {
+        $url = $this->get_base_url() . '/order/status';
+        $response = wp_remote_get(add_query_arg($query, $url), array(
+            'headers' => $this->get_headers(),
+            'timeout' => 20,
+        ));
+
+        return $this->parse_response($response);
+    }
+
+    private function parse_response($response)
+    {
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $status = (int) wp_remote_retrieve_response_code($response);
+        $body = wp_remote_retrieve_body($response);
+        $json = json_decode($body, true);
+
+        if ($status >= 400) {
+            $message = isset($json['error']) ? (string) $json['error'] : __('Bilinmeyen API hatası.', 'reseller-api');
+            return new WP_Error('rs_api_error', $message, $json);
+        }
+
+        if (!is_array($json)) {
+            return new WP_Error('rs_api_invalid', __('API yanıtı çözümlenemedi.', 'reseller-api'));
+        }
+
+        return $json;
+    }
+}

--- a/integrations/wordpress/reseller-api/reseller-api.php
+++ b/integrations/wordpress/reseller-api/reseller-api.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Plugin Name: Reseller Script WooCommerce Köprüsü
+ * Description: Reseller Script REST API'si ile WooCommerce ürün ve siparişlerini senkronize eder.
+ * Version: 2.0.0
+ * Author: Reseller Script
+ * Text Domain: reseller-api
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('RS_Api_Bridge')) {
+    require_once __DIR__ . '/includes/class-rs-api-client.php';
+
+    final class RS_Api_Bridge
+    {
+        public const OPTION_URL = 'rs_api_url';
+        public const OPTION_KEY = 'rs_api_key';
+        public const VERSION = '2.0.0';
+
+        private RS_Api_Client $client;
+
+        public function __construct()
+        {
+            add_action('admin_init', array($this, 'register_settings'));
+            add_action('admin_menu', array($this, 'register_menu'));
+            add_action('admin_post_rs_sync_products', array($this, 'handle_product_sync'));
+            add_action('woocommerce_checkout_order_processed', array($this, 'handle_checkout_order'), 10, 3);
+            add_action('woocommerce_order_status_processing', array($this, 'refresh_remote_status'), 10, 1);
+            add_action('woocommerce_order_status_completed', array($this, 'refresh_remote_status'), 10, 1);
+            $this->client = new RS_Api_Client();
+        }
+
+        public function register_settings(): void
+        {
+            register_setting('rs_api_settings', self::OPTION_URL, array(
+                'type' => 'string',
+                'sanitize_callback' => 'esc_url_raw',
+            ));
+
+            register_setting('rs_api_settings', self::OPTION_KEY, array(
+                'type' => 'string',
+                'sanitize_callback' => 'sanitize_text_field',
+            ));
+        }
+
+        public function register_menu(): void
+        {
+            add_submenu_page(
+                'woocommerce',
+                __('Reseller API', 'reseller-api'),
+                __('Reseller API', 'reseller-api'),
+                'manage_woocommerce',
+                'rs-api-settings',
+                array($this, 'render_settings_page')
+            );
+        }
+
+        public function render_settings_page(): void
+        {
+            if (!current_user_can('manage_woocommerce')) {
+                wp_die(__('Bu sayfaya erişim yetkiniz yok.', 'reseller-api'));
+            }
+
+            $apiUrl = esc_url(get_option(self::OPTION_URL, ''));
+            $apiKey = esc_attr(get_option(self::OPTION_KEY, ''));
+            $lastSync = esc_html(get_option('rs_api_last_sync', __('Senkr. yapılmadı', 'reseller-api')));
+            ?>
+            <div class="wrap">
+                <h1><?php esc_html_e('Reseller Script API Ayarları', 'reseller-api'); ?></h1>
+                <form method="post" action="options.php">
+                    <?php
+                    settings_fields('rs_api_settings');
+                    do_settings_sections('rs_api_settings');
+                    ?>
+                    <table class="form-table" role="presentation">
+                        <tr>
+                            <th scope="row"><label for="rs_api_url"><?php esc_html_e('API URL', 'reseller-api'); ?></label></th>
+                            <td><input type="url" class="regular-text" id="rs_api_url" name="<?= esc_attr(self::OPTION_URL); ?>" value="<?= $apiUrl; ?>" placeholder="https://panel.example.com/api/v2" required></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="rs_api_key"><?php esc_html_e('API Key', 'reseller-api'); ?></label></th>
+                            <td><input type="text" class="regular-text" id="rs_api_key" name="<?= esc_attr(self::OPTION_KEY); ?>" value="<?= $apiKey; ?>" required></td>
+                        </tr>
+                    </table>
+                    <?php submit_button(__('Ayarları Kaydet', 'reseller-api')); ?>
+                </form>
+
+                <h2><?php esc_html_e('Ürün Senkronizasyonu', 'reseller-api'); ?></h2>
+                <p><?php printf(esc_html__('Son senkronizasyon: %s', 'reseller-api'), $lastSync); ?></p>
+                <form method="post" action="<?= esc_url(admin_url('admin-post.php')); ?>">
+                    <?php wp_nonce_field('rs_sync_products'); ?>
+                    <input type="hidden" name="action" value="rs_sync_products">
+                    <?php submit_button(__('WooCommerce Ürünlerini Güncelle', 'reseller-api'), 'secondary'); ?>
+                </form>
+            </div>
+            <?php
+        }
+
+        public function handle_product_sync(): void
+        {
+            if (!current_user_can('manage_woocommerce') || !check_admin_referer('rs_sync_products')) {
+                wp_die(__('Geçersiz istek.', 'reseller-api'));
+            }
+
+            $response = $this->client->get_products();
+            if (is_wp_error($response)) {
+                wp_safe_redirect(add_query_arg('rs_sync', 'error', wp_get_referer()));
+                exit;
+            }
+
+            $products = is_array($response) ? ($response['data']['products'] ?? array()) : array();
+
+            $synced = 0;
+            foreach ($products as $product) {
+                $synced += $this->sync_product($product) ? 1 : 0;
+            }
+
+            update_option('rs_api_last_sync', current_time('mysql'));
+            wp_safe_redirect(add_query_arg('rs_sync', $synced, wp_get_referer()));
+            exit;
+        }
+
+        private function sync_product(array $remote): bool
+        {
+            if (!class_exists('WC_Product_Simple')) {
+                return false;
+            }
+
+            if (empty($remote['name'])) {
+                return false;
+            }
+
+            $sku = isset($remote['sku']) && $remote['sku'] !== '' ? $remote['sku'] : 'rs-' . (int) $remote['id'];
+            $productId = function_exists('wc_get_product_id_by_sku') ? wc_get_product_id_by_sku($sku) : 0;
+
+            if ($productId) {
+                $product = wc_get_product($productId);
+            } else {
+                $product = new WC_Product_Simple();
+                $product->set_sku($sku);
+            }
+
+            if (!$product) {
+                return false;
+            }
+
+            $product->set_name($remote['name']);
+            if (!empty($remote['description'])) {
+                $product->set_description($remote['description']);
+            }
+            if (isset($remote['price'])) {
+                $product->set_price((float) $remote['price']);
+                $product->set_regular_price((float) $remote['price']);
+            }
+            $product->set_catalog_visibility('visible');
+            $product->set_status('publish');
+            $product->set_virtual(true);
+            $product->save();
+
+            update_post_meta($product->get_id(), '_rs_api_product_id', (int) $remote['id']);
+            update_post_meta($product->get_id(), '_rs_api_provider', sanitize_text_field($remote['provider_code'] ?? '')); 
+
+            return true;
+        }
+
+        public function handle_checkout_order(int $orderId, array $postedData, $order): void
+        {
+            if (!class_exists('WC_Order')) {
+                return;
+            }
+
+            if (!$order instanceof WC_Order) {
+                $order = wc_get_order($orderId);
+            }
+
+            if (!$order) {
+                return;
+            }
+
+            foreach ($order->get_items() as $itemId => $item) {
+                $product = $item->get_product();
+                if (!$product) {
+                    continue;
+                }
+
+                $remoteId = (int) get_post_meta($product->get_id(), '_rs_api_product_id', true);
+                if ($remoteId <= 0) {
+                    continue;
+                }
+
+                $payload = array(
+                    'product_id' => $remoteId,
+                    'quantity' => (int) $item->get_quantity(),
+                    'external_reference' => sprintf('WC-%d-%d', $orderId, $itemId),
+                    'note' => $order->get_customer_note(),
+                );
+
+                $result = $this->client->create_order($payload);
+                if (is_wp_error($result)) {
+                    $order->add_order_note(sprintf(__('Reseller API siparişi oluşturulamadı: %s', 'reseller-api'), $result->get_error_message()));
+                    continue;
+                }
+
+                $data = is_array($result) ? ($result['data'] ?? array()) : array();
+                if (!empty($data['order_id'])) {
+                    update_post_meta($product->get_id(), '_rs_last_order_id', (int) $data['order_id']);
+                    $order->add_order_note(sprintf(__('Reseller API siparişi oluşturuldu (#%d).', 'reseller-api'), (int) $data['order_id']));
+                }
+            }
+        }
+
+        public function refresh_remote_status(int $orderId): void
+        {
+            $order = wc_get_order($orderId);
+            if (!$order) {
+                return;
+            }
+
+            $firstItem = current($order->get_items());
+            if (!$firstItem) {
+                return;
+            }
+
+            $reference = sprintf('WC-%d-%d', $orderId, $firstItem->get_id());
+            $result = $this->client->get_order_status(array('external_reference' => $reference));
+            if (is_wp_error($result)) {
+                $order->add_order_note(sprintf(__('API sipariş durumu alınamadı: %s', 'reseller-api'), $result->get_error_message()));
+                return;
+            }
+
+            $orderData = is_array($result) ? ($result['data']['order'] ?? array()) : array();
+            if (!empty($orderData['status'])) {
+                $order->add_order_note(sprintf(__('Sağlayıcı sipariş durumu: %s', 'reseller-api'), $orderData['status']));
+            }
+        }
+    }
+
+    add_action('plugins_loaded', static function () {
+        if (!class_exists('WooCommerce')) {
+            add_action('admin_notices', static function () {
+                echo '<div class="notice notice-error"><p>' . esc_html__('Reseller Script WooCommerce Köprüsü için WooCommerce kurulmalıdır.', 'reseller-api') . '</p></div>';
+            });
+            return;
+        }
+
+        new RS_Api_Bridge();
+    });
+}

--- a/schema.sql
+++ b/schema.sql
@@ -22,6 +22,13 @@ CREATE TABLE IF NOT EXISTS api_tokens (
     token VARCHAR(191) NOT NULL UNIQUE,
     label VARCHAR(150) NULL,
     webhook_url TEXT NULL,
+    status ENUM('active','disabled') NOT NULL DEFAULT 'active',
+    scopes TEXT NULL,
+    ip_whitelist TEXT NULL,
+    otp_secret VARCHAR(64) NULL,
+    hmac_secret VARCHAR(191) NULL,
+    rate_limit_per_minute INT NULL,
+    last_rotated_at DATETIME NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     last_used_at DATETIME NULL,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/src/Api/Controllers/BalanceController.php
+++ b/src/Api/Controllers/BalanceController.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Controllers;
+
+use App\Api\Exceptions\BadRequestException;
+use App\Api\Http\ApiResponse;
+use App\Api\Http\Request;
+use App\Api\Repositories\UserRepository;
+
+/**
+ * Kullanıcı bakiyesi sorgusunu sağlayan denetleyici.
+ */
+final class BalanceController
+{
+    private UserRepository $users;
+
+    public function __construct()
+    {
+        $this->users = new UserRepository();
+    }
+
+    public function show(Request $request): ApiResponse
+    {
+        $token = $request->getToken();
+        if ($token === null) {
+            throw new BadRequestException('Kimlik doğrulama başarısız.');
+        }
+
+        $userId = isset($token['user_id']) ? (int) $token['user_id'] : 0;
+        if ($userId <= 0) {
+            throw new BadRequestException('API anahtarı için kullanıcı bulunamadı.');
+        }
+
+        $user = $this->users->findById($userId);
+        if ($user === null) {
+            throw new BadRequestException('Kullanıcı bulunamadı.');
+        }
+
+        return new ApiResponse(array(
+            'data' => array(
+                'balance' => $user['balance'],
+                'currency' => 'TRY',
+                'updated_at' => $user['updated_at'],
+            ),
+        ));
+    }
+}

--- a/src/Api/Controllers/OrderController.php
+++ b/src/Api/Controllers/OrderController.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Controllers;
+
+use App\Api\Exceptions\BadRequestException;
+use App\Api\Exceptions\NotFoundException;
+use App\Api\Exceptions\ValidationException;
+use App\Api\Http\ApiResponse;
+use App\Api\Http\Request;
+use App\Api\Repositories\OrderRepository;
+use App\Api\Repositories\ProductRepository;
+use App\Api\Repositories\UserRepository;
+use App\Api\Services\OrderService;
+
+/**
+ * Sipariş oluşturma ve durum sorgulama uç noktalarını yönetir.
+ */
+final class OrderController
+{
+    private OrderService $service;
+
+    public function __construct()
+    {
+        $this->service = new OrderService(
+            new ProductRepository(),
+            new OrderRepository(),
+            new UserRepository()
+        );
+    }
+
+    public function create(Request $request): ApiResponse
+    {
+        $token = $request->getToken();
+        if ($token === null) {
+            throw new BadRequestException('Kimlik doğrulama başarısız.');
+        }
+
+        $payload = $request->getJsonBody();
+        $result = $this->service->createOrder($token, $payload);
+
+        return new ApiResponse(array(
+            'data' => $result,
+        ), 201);
+    }
+
+    public function status(Request $request): ApiResponse
+    {
+        $token = $request->getToken();
+        if ($token === null) {
+            throw new BadRequestException('Kimlik doğrulama başarısız.');
+        }
+
+        $orderId = null;
+        $reference = null;
+
+        if ($request->hasQuery('order_id')) {
+            $orderId = (int) $request->query('order_id');
+        }
+
+        if ($request->hasQuery('external_reference')) {
+            $reference = (string) $request->query('external_reference');
+        }
+
+        if (($orderId === null || $orderId <= 0) && ($reference === null || $reference === '')) {
+            throw new ValidationException('Sipariş sorgusu doğrulanamadı.', array(
+                'order_id' => 'order_id veya external_reference parametrelerinden en az biri gereklidir.',
+            ));
+        }
+
+        $userId = isset($token['user_id']) ? (int) $token['user_id'] : 0;
+        if ($userId <= 0) {
+            throw new BadRequestException('API anahtarı için kullanıcı bulunamadı.');
+        }
+
+        if ($orderId !== null && $orderId > 0) {
+            $order = $this->service->findOrderById($orderId, $userId);
+        } else {
+            $order = $this->service->findOrderByReference((string) $reference, $userId);
+        }
+
+        if ($order === null) {
+            throw new NotFoundException('Sipariş bulunamadı.');
+        }
+
+        return new ApiResponse(array(
+            'data' => array('order' => $order),
+        ));
+    }
+}

--- a/src/Api/Controllers/ProductController.php
+++ b/src/Api/Controllers/ProductController.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Controllers;
+
+use App\Api\Http\ApiResponse;
+use App\Api\Http\Request;
+use App\Api\Repositories\ProductRepository;
+
+/**
+ * Ürün listeleme uç noktasını yöneten denetleyici.
+ */
+final class ProductController
+{
+    private ProductRepository $repository;
+
+    public function __construct()
+    {
+        $this->repository = new ProductRepository();
+    }
+
+    public function index(Request $request): ApiResponse
+    {
+        $products = $this->repository->listActive();
+
+        return new ApiResponse(array(
+            'data' => array(
+                'products' => $products,
+                'count' => count($products),
+            ),
+        ));
+    }
+}

--- a/src/Api/Controllers/UserController.php
+++ b/src/Api/Controllers/UserController.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Controllers;
+
+use App\Api\Exceptions\BadRequestException;
+use App\Api\Http\ApiResponse;
+use App\Api\Http\Request;
+use App\Api\Repositories\UserRepository;
+
+/**
+ * Bayi ve token meta verilerini döndüren uç nokta denetleyicisi.
+ */
+final class UserController
+{
+    private UserRepository $users;
+
+    public function __construct()
+    {
+        $this->users = new UserRepository();
+    }
+
+    public function info(Request $request): ApiResponse
+    {
+        $token = $request->getToken();
+        if ($token === null) {
+            throw new BadRequestException('Kimlik doğrulama başarısız.');
+        }
+
+        $userId = isset($token['user_id']) ? (int) $token['user_id'] : 0;
+        if ($userId <= 0) {
+            throw new BadRequestException('API anahtarı için kullanıcı bulunamadı.');
+        }
+
+        $user = $this->users->findById($userId);
+        if ($user === null) {
+            throw new BadRequestException('Kullanıcı bulunamadı.');
+        }
+
+        $tokenInfo = array(
+            'token_id' => isset($token['token_id']) ? (int) $token['token_id'] : null,
+            'label' => $token['label'] ?? null,
+            'scopes' => $token['scopes'] ?? null,
+            'ip_whitelist' => $token['ip_whitelist'] ?? null,
+            'rate_limit_per_minute' => $token['rate_limit_per_minute'] ?? null,
+        );
+
+        return new ApiResponse(array(
+            'data' => array(
+                'user' => $user,
+                'token' => $tokenInfo,
+            ),
+        ));
+    }
+}

--- a/src/Api/Exceptions/ApiException.php
+++ b/src/Api/Exceptions/ApiException.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Exceptions;
+
+use RuntimeException;
+
+/**
+ * API katmanı için temel istisna sınıfı.
+ */
+class ApiException extends RuntimeException
+{
+    protected int $statusCode;
+    /** @var array<int|string,mixed> */
+    protected array $errors;
+
+    /**
+     * @param array<int|string,mixed> $errors
+     */
+    public function __construct(string $message, int $statusCode = 400, array $errors = array())
+    {
+        parent::__construct($message);
+        $this->statusCode = $statusCode;
+        $this->errors = $errors;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * @return array<int|string,mixed>
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Api/Exceptions/AuthenticationException.php
+++ b/src/Api/Exceptions/AuthenticationException.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Exceptions;
+
+/**
+ * Kimlik doğrulama hatalarını temsil eder.
+ */
+final class AuthenticationException extends ApiException
+{
+    public function __construct(string $message = 'Kimlik doğrulaması başarısız oldu.')
+    {
+        parent::__construct($message, 401);
+    }
+}

--- a/src/Api/Exceptions/AuthorizationException.php
+++ b/src/Api/Exceptions/AuthorizationException.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Exceptions;
+
+/**
+ * Yetki yetersizliği durumlarını temsil eder.
+ */
+final class AuthorizationException extends ApiException
+{
+    public function __construct(string $message = 'Bu işleme yetkiniz bulunmuyor.')
+    {
+        parent::__construct($message, 403);
+    }
+}

--- a/src/Api/Exceptions/BadRequestException.php
+++ b/src/Api/Exceptions/BadRequestException.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Exceptions;
+
+/**
+ * Geçersiz veya eksik istek durumunu temsil eder.
+ */
+final class BadRequestException extends ApiException
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 400);
+    }
+}

--- a/src/Api/Exceptions/NotFoundException.php
+++ b/src/Api/Exceptions/NotFoundException.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Exceptions;
+
+/**
+ * Kaynak bulunamadığında kullanılan istisna.
+ */
+final class NotFoundException extends ApiException
+{
+    public function __construct(string $message = 'Kayıt bulunamadı.')
+    {
+        parent::__construct($message, 404);
+    }
+}

--- a/src/Api/Exceptions/ValidationException.php
+++ b/src/Api/Exceptions/ValidationException.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Exceptions;
+
+/**
+ * Alan doğrulama hatalarını temsil eder.
+ */
+final class ValidationException extends ApiException
+{
+    /**
+     * @param array<int|string,mixed> $errors
+     */
+    public function __construct(string $message, array $errors)
+    {
+        parent::__construct($message, 422, $errors);
+    }
+}

--- a/src/Api/Http/ApiResponse.php
+++ b/src/Api/Http/ApiResponse.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Http;
+
+/**
+ * Standart JSON yanıt gövdesini sarmalayan basit taşıyıcı sınıf.
+ */
+final class ApiResponse
+{
+    /** @var array<string,mixed> */
+    private array $payload;
+    private int $status;
+
+    /**
+     * @param array<string,mixed> $payload
+     */
+    public function __construct(array $payload, int $status = 200)
+    {
+        $this->payload = $payload;
+        $this->status = $status;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+}

--- a/src/Api/Http/Request.php
+++ b/src/Api/Http/Request.php
@@ -1,0 +1,211 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Http;
+
+use App\Api\Exceptions\BadRequestException;
+
+/**
+ * HTTP istek verilerini temsil eden yardımcı sınıf.
+ */
+final class Request
+{
+    private string $method;
+    private string $path;
+    private string $basePath;
+    private string $relativePath;
+    /** @var array<string,mixed> */
+    private array $query;
+    /** @var array<string,string> */
+    private array $headers;
+    private string $rawBody;
+    /** @var array<string,mixed>|null */
+    private ?array $jsonBody = null;
+    private bool $jsonParsed = false;
+    private string $ipAddress;
+    /** @var array<string,mixed>|null */
+    private ?array $token = null;
+
+    /**
+     * @param array<string,mixed> $query
+     * @param array<string,string> $headers
+     */
+    private function __construct(
+        string $method,
+        string $path,
+        string $basePath,
+        string $relativePath,
+        array $query,
+        array $headers,
+        string $rawBody,
+        string $ipAddress
+    ) {
+        $this->method = strtoupper($method);
+        $this->path = $path !== '' ? $path : '/';
+        $this->basePath = $basePath;
+        $this->relativePath = $relativePath !== '' ? $relativePath : '/';
+        $this->query = $query;
+        $this->headers = $headers;
+        $this->rawBody = $rawBody;
+        $this->ipAddress = $ipAddress;
+    }
+
+    public static function fromGlobals(string $basePath = ''): self
+    {
+        $uri = isset($_SERVER['REQUEST_URI']) ? (string) $_SERVER['REQUEST_URI'] : '/';
+        $path = (string) (parse_url($uri, PHP_URL_PATH) ?: '/');
+        $relative = $path;
+
+        if ($basePath !== '' && str_starts_with($path, $basePath)) {
+            $relative = substr($path, strlen($basePath));
+            if ($relative === false || $relative === '') {
+                $relative = '/';
+            }
+        }
+
+        $method = isset($_SERVER['REQUEST_METHOD']) ? (string) $_SERVER['REQUEST_METHOD'] : 'GET';
+        $query = $_GET ?? array();
+
+        $headers = array();
+        if (function_exists('getallheaders')) {
+            $serverHeaders = getallheaders();
+            if (is_array($serverHeaders)) {
+                foreach ($serverHeaders as $name => $value) {
+                    $headers[strtolower((string) $name)] = (string) $value;
+                }
+            }
+        }
+
+        foreach ($_SERVER as $key => $value) {
+            if (strpos($key, 'HTTP_') === 0) {
+                $name = strtolower(str_replace('_', '-', substr($key, 5)));
+                if (!isset($headers[$name])) {
+                    $headers[$name] = (string) $value;
+                }
+            }
+        }
+
+        $rawBody = '';
+        if (function_exists('api_raw_body')) {
+            $rawBody = (string) call_user_func('api_raw_body');
+        } else {
+            $rawBody = file_get_contents('php://input') ?: '';
+        }
+
+        $ip = '0.0.0.0';
+        if (function_exists('api_client_ip')) {
+            $ip = (string) call_user_func('api_client_ip');
+        } elseif (!empty($_SERVER['REMOTE_ADDR'])) {
+            $ip = (string) $_SERVER['REMOTE_ADDR'];
+        }
+
+        return new self($method, $path, $basePath, $relative, $query, $headers, $rawBody, $ip);
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function getPath(): string
+    {
+        return $this->relativePath;
+    }
+
+    public function getFullPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getBasePath(): string
+    {
+        return $this->basePath;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getQuery(): array
+    {
+        return $this->query;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public function query(string $key, $default = null)
+    {
+        return $this->query[$key] ?? $default;
+    }
+
+    public function hasQuery(string $key): bool
+    {
+        return array_key_exists($key, $this->query);
+    }
+
+    public function header(string $name, ?string $default = null): ?string
+    {
+        $key = strtolower($name);
+        return $this->headers[$key] ?? $default;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getJsonBody(): array
+    {
+        if ($this->jsonParsed) {
+            return $this->jsonBody ?? array();
+        }
+
+        $this->jsonParsed = true;
+
+        if ($this->rawBody === '') {
+            $this->jsonBody = array();
+            return $this->jsonBody;
+        }
+
+        $decoded = json_decode($this->rawBody, true);
+        if (!is_array($decoded)) {
+            throw new BadRequestException('Geçersiz JSON içeriği.');
+        }
+
+        $this->jsonBody = $decoded;
+        return $decoded;
+    }
+
+    public function getRawBody(): string
+    {
+        return $this->rawBody;
+    }
+
+    public function getIpAddress(): string
+    {
+        return $this->ipAddress;
+    }
+
+    /**
+     * @param array<string,mixed> $token
+     */
+    public function setToken(array $token): void
+    {
+        $this->token = $token;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function getToken(): ?array
+    {
+        return $this->token;
+    }
+}

--- a/src/Api/Repositories/OrderRepository.php
+++ b/src/Api/Repositories/OrderRepository.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Repositories;
+
+use App\Database;
+use PDO;
+
+/**
+ * Sipariş kayıtlarını kullanıcı bazında okuyan depo sınıfı.
+ */
+final class OrderRepository
+{
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function findForUserById(int $orderId, int $userId): ?array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare(
+            'SELECT po.*, p.name AS product_name, p.sku AS product_sku ' .
+            'FROM product_orders po INNER JOIN products p ON p.id = po.product_id ' .
+            'WHERE po.id = :id AND po.user_id = :user_id LIMIT 1'
+        );
+        $stmt->execute(array('id' => $orderId, 'user_id' => $userId));
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            return null;
+        }
+
+        return $this->normalizeOrderRow($row);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function findForUserByReference(string $externalReference, int $userId): ?array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare(
+            'SELECT po.*, p.name AS product_name, p.sku AS product_sku ' .
+            'FROM product_orders po INNER JOIN products p ON p.id = po.product_id ' .
+            'WHERE po.external_reference = :reference AND po.user_id = :user_id LIMIT 1'
+        );
+        $stmt->execute(array('reference' => $externalReference, 'user_id' => $userId));
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            return null;
+        }
+
+        return $this->normalizeOrderRow($row);
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @return array<string,mixed>
+     */
+    private function normalizeOrderRow(array $row): array
+    {
+        $metadata = array();
+        if (!empty($row['external_metadata'])) {
+            $decoded = json_decode((string) $row['external_metadata'], true);
+            if (is_array($decoded)) {
+                $metadata = $decoded;
+            }
+        }
+
+        return array(
+            'id' => (int) $row['id'],
+            'product_id' => (int) $row['product_id'],
+            'user_id' => (int) $row['user_id'],
+            'api_token_id' => isset($row['api_token_id']) ? (int) $row['api_token_id'] : null,
+            'quantity' => isset($row['quantity']) ? (int) $row['quantity'] : 1,
+            'price' => isset($row['price']) ? (float) $row['price'] : 0.0,
+            'total_amount' => isset($row['total_amount']) ? (float) $row['total_amount'] : ((isset($row['price']) ? (float) $row['price'] : 0.0) * (isset($row['quantity']) ? (int) $row['quantity'] : 1)),
+            'status' => isset($row['status']) ? (string) $row['status'] : 'pending',
+            'note' => isset($row['note']) ? (string) $row['note'] : null,
+            'admin_note' => isset($row['admin_note']) ? (string) $row['admin_note'] : null,
+            'external_reference' => isset($row['external_reference']) ? (string) $row['external_reference'] : null,
+            'product_name' => isset($row['product_name']) ? (string) $row['product_name'] : null,
+            'product_sku' => isset($row['product_sku']) ? (string) $row['product_sku'] : null,
+            'created_at' => isset($row['created_at']) ? (string) $row['created_at'] : null,
+            'updated_at' => isset($row['updated_at']) ? (string) $row['updated_at'] : null,
+            'metadata' => $metadata,
+        );
+    }
+}

--- a/src/Api/Repositories/ProductRepository.php
+++ b/src/Api/Repositories/ProductRepository.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Repositories;
+
+use App\Database;
+use PDO;
+
+/**
+ * Ürün verilerini API katmanı için okuyan depo sınıfı.
+ */
+final class ProductRepository
+{
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function listActive(): array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->query(
+            'SELECT p.id, p.name, p.sku, p.description, p.price, p.status, p.automatic_delivery, p.provider_code, ' .
+            'p.provider_product_id, p.updated_at, c.id AS category_id, c.name AS category_name ' .
+            'FROM products p INNER JOIN categories c ON c.id = p.category_id ' .
+            "WHERE p.status = 'active' ORDER BY c.name ASC, p.name ASC"
+        );
+
+        $rows = $stmt !== false ? $stmt->fetchAll(PDO::FETCH_ASSOC) : array();
+        if (!$rows) {
+            return array();
+        }
+
+        return array_map(static function ($row) {
+            return array(
+                'id' => (int) $row['id'],
+                'name' => (string) $row['name'],
+                'sku' => isset($row['sku']) ? (string) $row['sku'] : null,
+                'description' => isset($row['description']) ? (string) $row['description'] : null,
+                'price' => isset($row['price']) ? (float) $row['price'] : 0.0,
+                'status' => (string) $row['status'],
+                'automatic_delivery' => isset($row['automatic_delivery']) ? (int) $row['automatic_delivery'] === 1 : false,
+                'provider_code' => isset($row['provider_code']) ? (string) $row['provider_code'] : null,
+                'provider_product_id' => isset($row['provider_product_id']) ? (string) $row['provider_product_id'] : null,
+                'category' => array(
+                    'id' => isset($row['category_id']) ? (int) $row['category_id'] : null,
+                    'name' => isset($row['category_name']) ? (string) $row['category_name'] : null,
+                ),
+                'updated_at' => isset($row['updated_at']) ? (string) $row['updated_at'] : null,
+            );
+        }, $rows);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function findActiveById(int $productId): ?array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare(
+            'SELECT p.*, c.name AS category_name FROM products p INNER JOIN categories c ON c.id = p.category_id ' .
+            "WHERE p.id = :id AND p.status = 'active' LIMIT 1"
+        );
+        $stmt->execute(array('id' => $productId));
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            return null;
+        }
+
+        return $this->normalizeProductRow($row);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function findActiveBySku(string $sku): ?array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare(
+            'SELECT p.*, c.name AS category_name FROM products p INNER JOIN categories c ON c.id = p.category_id ' .
+            "WHERE p.sku = :sku AND p.status = 'active' LIMIT 1"
+        );
+        $stmt->execute(array('sku' => $sku));
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            return null;
+        }
+
+        return $this->normalizeProductRow($row);
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @return array<string,mixed>
+     */
+    private function normalizeProductRow(array $row): array
+    {
+        return array(
+            'id' => (int) $row['id'],
+            'category_id' => isset($row['category_id']) ? (int) $row['category_id'] : null,
+            'name' => (string) $row['name'],
+            'sku' => isset($row['sku']) ? (string) $row['sku'] : null,
+            'description' => isset($row['description']) ? (string) $row['description'] : null,
+            'price' => isset($row['price']) ? (float) $row['price'] : 0.0,
+            'status' => isset($row['status']) ? (string) $row['status'] : 'inactive',
+            'automatic_delivery' => isset($row['automatic_delivery']) ? (int) $row['automatic_delivery'] === 1 : false,
+            'provider_code' => isset($row['provider_code']) ? (string) $row['provider_code'] : null,
+            'provider_product_id' => isset($row['provider_product_id']) ? (string) $row['provider_product_id'] : null,
+            'category_name' => isset($row['category_name']) ? (string) $row['category_name'] : null,
+            'updated_at' => isset($row['updated_at']) ? (string) $row['updated_at'] : null,
+        );
+    }
+}

--- a/src/Api/Repositories/UserRepository.php
+++ b/src/Api/Repositories/UserRepository.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Repositories;
+
+use App\Database;
+use PDO;
+
+/**
+ * Bayi kullanıcı kayıtlarını sağlayan depo sınıfı.
+ */
+final class UserRepository
+{
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function findById(int $userId): ?array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT id, name, email, balance, status, role, created_at, updated_at FROM users WHERE id = :id LIMIT 1');
+        $stmt->execute(array('id' => $userId));
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            return null;
+        }
+
+        return array(
+            'id' => (int) $row['id'],
+            'name' => (string) $row['name'],
+            'email' => (string) $row['email'],
+            'balance' => isset($row['balance']) ? (float) $row['balance'] : 0.0,
+            'status' => isset($row['status']) ? (string) $row['status'] : 'inactive',
+            'role' => isset($row['role']) ? (string) $row['role'] : 'reseller',
+            'created_at' => isset($row['created_at']) ? (string) $row['created_at'] : null,
+            'updated_at' => isset($row['updated_at']) ? (string) $row['updated_at'] : null,
+        );
+    }
+}

--- a/src/Api/Routing/Router.php
+++ b/src/Api/Routing/Router.php
@@ -1,0 +1,150 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Routing;
+
+use App\Api\Exceptions\ApiException;
+use App\Api\Http\ApiResponse;
+use App\Api\Http\Request;
+use Throwable;
+
+/**
+ * Basit rota tanımlama ve dağıtım mekanizması.
+ */
+final class Router
+{
+    private string $basePath;
+    /** @var array<int,array{method:string,path:string,handler:callable}> */
+    private array $routes = array();
+
+    public function __construct(string $basePath = '')
+    {
+        $this->basePath = $basePath;
+    }
+
+    public function get(string $path, callable $handler): self
+    {
+        return $this->add('GET', $path, $handler);
+    }
+
+    public function post(string $path, callable $handler): self
+    {
+        return $this->add('POST', $path, $handler);
+    }
+
+    public function put(string $path, callable $handler): self
+    {
+        return $this->add('PUT', $path, $handler);
+    }
+
+    public function patch(string $path, callable $handler): self
+    {
+        return $this->add('PATCH', $path, $handler);
+    }
+
+    public function delete(string $path, callable $handler): self
+    {
+        return $this->add('DELETE', $path, $handler);
+    }
+
+    private function add(string $method, string $path, callable $handler): self
+    {
+        $normalized = $this->normalizePath($path);
+        $this->routes[] = array(
+            'method' => strtoupper($method),
+            'path' => $normalized,
+            'handler' => $handler,
+        );
+
+        return $this;
+    }
+
+    public function dispatch(Request $request): void
+    {
+        $requestPath = $this->normalizePath($request->getPath());
+        $method = strtoupper($request->getMethod());
+
+        foreach ($this->routes as $route) {
+            if ($route['method'] !== $method) {
+                continue;
+            }
+
+            if ($route['path'] !== $requestPath) {
+                continue;
+            }
+
+            $this->invoke($route['handler'], $request);
+            return;
+        }
+
+        json_response(array(
+            'success' => false,
+            'error' => 'İstenen uç nokta bulunamadı.',
+            'meta' => array(
+                'path' => $request->getFullPath(),
+            ),
+        ), 404);
+    }
+
+    private function invoke(callable $handler, Request $request): void
+    {
+        try {
+            $result = $handler($request);
+        } catch (ApiException $apiException) {
+            $payload = array(
+                'success' => false,
+                'error' => $apiException->getMessage(),
+            );
+
+            $errors = $apiException->getErrors();
+            if ($errors !== array()) {
+                $payload['errors'] = $errors;
+            }
+
+            json_response($payload, $apiException->getStatusCode());
+            return;
+        } catch (Throwable $throwable) {
+            error_log('[API] Unhandled exception: ' . $throwable->getMessage());
+            json_response(array(
+                'success' => false,
+                'error' => 'Beklenmeyen bir hata oluştu.',
+            ), 500);
+            return;
+        }
+
+        if ($result instanceof ApiResponse) {
+            json_response($result->getPayload(), $result->getStatus());
+            return;
+        }
+
+        if (is_array($result)) {
+            $status = 200;
+            if (isset($result['_status'])) {
+                $status = (int) $result['_status'];
+                unset($result['_status']);
+            }
+
+            json_response($result, $status);
+            return;
+        }
+
+        if ($result === null) {
+            return;
+        }
+
+        json_response(array('data' => $result), 200);
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $normalized = '/' . ltrim($path, '/');
+        if ($normalized !== '/' && str_ends_with($normalized, '/')) {
+            $normalized = rtrim($normalized, '/');
+        }
+
+        if ($normalized === '') {
+            return '/';
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Api/Services/OrderService.php
+++ b/src/Api/Services/OrderService.php
@@ -1,0 +1,272 @@
+<?php declare(strict_types=1);
+
+namespace App\Api\Services;
+
+use App\Api\Exceptions\BadRequestException;
+use App\Api\Exceptions\ValidationException;
+use App\Api\Repositories\OrderRepository;
+use App\Api\Repositories\ProductRepository;
+use App\Api\Repositories\UserRepository;
+use App\Database;
+use App\Services\ProviderDispatchService;
+use PDO;
+use RuntimeException;
+
+/**
+ * API üzerinden sipariş oluşturma ve sorgulama süreçlerini yönetir.
+ */
+final class OrderService
+{
+    private ProductRepository $productRepository;
+    private OrderRepository $orderRepository;
+    private UserRepository $userRepository;
+
+    public function __construct(
+        ProductRepository $productRepository,
+        OrderRepository $orderRepository,
+        UserRepository $userRepository
+    ) {
+        $this->productRepository = $productRepository;
+        $this->orderRepository = $orderRepository;
+        $this->userRepository = $userRepository;
+    }
+
+    /**
+     * @param array<string,mixed> $tokenRow
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>
+     */
+    public function createOrder(array $tokenRow, array $payload): array
+    {
+        $userId = isset($tokenRow['user_id']) ? (int) $tokenRow['user_id'] : 0;
+        if ($userId <= 0) {
+            throw new BadRequestException('API anahtarı geçersiz kullanıcıya ait.');
+        }
+
+        $productId = isset($payload['product_id']) ? (int) $payload['product_id'] : 0;
+        $sku = isset($payload['sku']) ? trim((string) $payload['sku']) : '';
+        $quantity = isset($payload['quantity']) ? (int) $payload['quantity'] : 1;
+        $note = isset($payload['note']) ? trim((string) $payload['note']) : null;
+        $externalReference = isset($payload['external_reference']) ? trim((string) $payload['external_reference']) : null;
+        $metadata = isset($payload['metadata']) && is_array($payload['metadata']) ? $payload['metadata'] : array();
+
+        $errors = array();
+        if ($productId <= 0 && $sku === '') {
+            $errors['product'] = 'Lütfen ürün numarası veya SKU değeri gönderin.';
+        }
+
+        if ($quantity <= 0) {
+            $errors['quantity'] = 'Adet değeri pozitif olmalıdır.';
+        }
+
+        if (mb_strlen((string) $externalReference) > 191) {
+            $errors['external_reference'] = 'external_reference alanı 191 karakterden uzun olamaz.';
+        }
+
+        if ($errors !== array()) {
+            throw new ValidationException('Sipariş isteği doğrulanamadı.', $errors);
+        }
+
+        if ($quantity > 100) {
+            throw new ValidationException('Sipariş isteği doğrulanamadı.', array(
+                'quantity' => 'En fazla 100 adet sipariş edilebilir.',
+            ));
+        }
+
+        $product = null;
+        if ($productId > 0) {
+            $product = $this->productRepository->findActiveById($productId);
+        }
+
+        if ($product === null && $sku !== '') {
+            $product = $this->productRepository->findActiveBySku($sku);
+        }
+
+        if ($product === null) {
+            throw new BadRequestException('Ürün bulunamadı veya pasif durumda.');
+        }
+
+        $user = $this->userRepository->findById($userId);
+        if ($user === null || ($user['status'] ?? '') !== 'active') {
+            throw new BadRequestException('Kullanıcı hesabı aktif değil.');
+        }
+
+        $pdo = Database::connection();
+        $currentBalance = isset($user['balance']) ? (float) $user['balance'] : 0.0;
+        $price = 0.0;
+        $total = 0.0;
+        $orderId = 0;
+
+        try {
+            $pdo->beginTransaction();
+
+            if ($externalReference !== null && $externalReference !== '') {
+                $dupStmt = $pdo->prepare('SELECT id FROM product_orders WHERE user_id = :user_id AND external_reference = :reference LIMIT 1 FOR UPDATE');
+                $dupStmt->execute(array(
+                    'user_id' => $userId,
+                    'reference' => $externalReference,
+                ));
+
+                if ($dupStmt->fetch(PDO::FETCH_ASSOC)) {
+                    $pdo->rollBack();
+                    throw new ValidationException('Sipariş isteği doğrulanamadı.', array(
+                        'external_reference' => 'Bu external_reference daha önce kullanılmış.',
+                    ));
+                }
+            }
+
+            $productStmt = $pdo->prepare('SELECT * FROM products WHERE id = :id AND status = :status FOR UPDATE');
+            $productStmt->execute(array(
+                'id' => $product['id'],
+                'status' => 'active',
+            ));
+            $productRow = $productStmt->fetch(PDO::FETCH_ASSOC);
+
+            if (!$productRow) {
+                $pdo->rollBack();
+                throw new BadRequestException('Ürün bulunamadı veya pasif durumda.');
+            }
+
+            $userStmt = $pdo->prepare('SELECT id, balance FROM users WHERE id = :id LIMIT 1 FOR UPDATE');
+            $userStmt->execute(array('id' => $userId));
+            $userRow = $userStmt->fetch(PDO::FETCH_ASSOC);
+            if (!$userRow) {
+                $pdo->rollBack();
+                throw new BadRequestException('Kullanıcı bulunamadı.');
+            }
+
+            $price = isset($productRow['price']) ? (float) $productRow['price'] : 0.0;
+            $total = $price * $quantity;
+            $currentBalance = isset($userRow['balance']) ? (float) $userRow['balance'] : 0.0;
+
+            if ($total > $currentBalance) {
+                $pdo->rollBack();
+                throw new ValidationException('Sipariş isteği doğrulanamadı.', array(
+                    'balance' => 'Bakiyeniz siparişi oluşturmak için yetersiz.',
+                ));
+            }
+
+            $providerCode = isset($productRow['provider_code']) ? strtolower((string) $productRow['provider_code']) : '';
+            $automaticDelivery = isset($productRow['automatic_delivery']) ? (int) $productRow['automatic_delivery'] === 1 : false;
+            $useLocalStock = ($providerCode === '' || $providerCode === 'stock' || $providerCode === 'panel') && !$automaticDelivery;
+
+            if ($useLocalStock) {
+                $stockStmt = $pdo->prepare('SELECT COUNT(*) AS total FROM product_stock_items WHERE product_id = :product_id AND status = "available" FOR UPDATE');
+                $stockStmt->execute(array('product_id' => $product['id']));
+                $available = (int) $stockStmt->fetchColumn();
+                if ($available < $quantity) {
+                    $pdo->rollBack();
+                    throw new ValidationException('Sipariş isteği doğrulanamadı.', array(
+                        'quantity' => 'İstenen adet için stok bulunmuyor.',
+                    ));
+                }
+            }
+
+            $metadataJson = null;
+            if ($metadata !== array()) {
+                $encoded = json_encode($metadata, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                if ($encoded !== false) {
+                    $metadataJson = $encoded;
+                }
+            }
+
+            $orderStmt = $pdo->prepare(
+                'INSERT INTO product_orders (product_id, user_id, api_token_id, quantity, note, price, total_amount, status, source, external_reference, external_metadata, created_at) ' .
+                'VALUES (:product_id, :user_id, :api_token_id, :quantity, :note, :price, :total_amount, :status, :source, :external_reference, :metadata, NOW())'
+            );
+            $orderStmt->execute(array(
+                'product_id' => $product['id'],
+                'user_id' => $userId,
+                'api_token_id' => isset($tokenRow['token_id']) ? (int) $tokenRow['token_id'] : null,
+                'quantity' => $quantity,
+                'note' => $note,
+                'price' => $price,
+                'total_amount' => $total,
+                'status' => 'pending',
+                'source' => 'api',
+                'external_reference' => $externalReference,
+                'metadata' => $metadataJson,
+            ));
+
+            $orderId = (int) $pdo->lastInsertId();
+
+            $balanceUpdate = $pdo->prepare('UPDATE users SET balance = balance - :amount WHERE id = :id');
+            $balanceUpdate->execute(array(
+                'amount' => $total,
+                'id' => $userId,
+            ));
+
+            $transactionStmt = $pdo->prepare('INSERT INTO balance_transactions (user_id, amount, type, description, created_at) VALUES (:user_id, :amount, :type, :description, NOW())');
+            $transactionStmt->execute(array(
+                'user_id' => $userId,
+                'amount' => $total,
+                'type' => 'debit',
+                'description' => 'API siparişi: ' . $productRow['name'],
+            ));
+
+            $pdo->commit();
+        } catch (ValidationException $validationException) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            throw $validationException;
+        } catch (BadRequestException $badRequestException) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            throw $badRequestException;
+        } catch (RuntimeException $runtimeException) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            throw $runtimeException;
+        } catch (\Throwable $throwable) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            throw new RuntimeException('Sipariş oluşturulurken beklenmeyen bir hata oluştu: ' . $throwable->getMessage(), 0, $throwable);
+        }
+
+        $dispatchResult = ProviderDispatchService::dispatchProductOrder($orderId ?? 0);
+
+        $response = array(
+            'order_id' => $orderId,
+            'status' => isset($dispatchResult['status']) ? (string) $dispatchResult['status'] : 'pending',
+            'message' => isset($dispatchResult['message']) ? (string) $dispatchResult['message'] : 'Sipariş başarıyla oluşturuldu.',
+            'product' => array(
+                'id' => $product['id'],
+                'name' => $product['name'],
+                'sku' => $product['sku'],
+            ),
+            'quantity' => $quantity,
+            'total_amount' => $total,
+            'remaining_balance' => $currentBalance - $total,
+        );
+
+        if (!empty($dispatchResult['content'])) {
+            $response['delivery'] = $dispatchResult['content'];
+        }
+
+        if (!empty($dispatchResult['reason'])) {
+            $response['provider_note'] = (string) $dispatchResult['reason'];
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function findOrderById(int $orderId, int $userId): ?array
+    {
+        return $this->orderRepository->findForUserById($orderId, $userId);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function findOrderByReference(string $reference, int $userId): ?array
+    {
+        return $this->orderRepository->findForUserByReference($reference, $userId);
+    }
+}

--- a/src/Migrations/Schema.php
+++ b/src/Migrations/Schema.php
@@ -126,6 +126,8 @@ final class Schema
         self::ensureColumn($pdo, 'api_tokens', 'scopes', 'TEXT NULL');
         self::ensureColumn($pdo, 'api_tokens', 'ip_whitelist', 'TEXT NULL');
         self::ensureColumn($pdo, 'api_tokens', 'otp_secret', 'VARCHAR(64) NULL');
+        self::ensureColumn($pdo, 'api_tokens', 'hmac_secret', 'VARCHAR(191) NULL');
+        self::ensureColumn($pdo, 'api_tokens', 'rate_limit_per_minute', 'INT NULL');
         self::ensureColumn($pdo, 'api_tokens', 'last_rotated_at', 'DATETIME NULL');
     }
 


### PR DESCRIPTION
## Summary
- introduce a PSR-4 structured API v2 router with controllers, repositories, and services for products, orders, balance, and user endpoints
- harden authentication with token scoped rate limiting, optional HMAC signatures, and ship full Swagger/OpenAPI + Postman documentation alongside PHP/Node/Python SDKs
- add a WooCommerce bridge plugin that syncs products, submits API orders, and updates order notes using the new REST endpoints

## Testing
- php -l api/v2/index.php
- php -l src/Api/Services/OrderService.php
- php -l integrations/wordpress/reseller-api/reseller-api.php


------
https://chatgpt.com/codex/tasks/task_b_68e3e03993b48321a436867c560ccafb