### PR TITLE
Fix provider API test failures without external HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ Bu depo, ePin, lisans ve dijital hesap satış süreçlerini yönetmek için gel
 1. `composer install`
 2. `cp config/config.sample.php config/config.php` ve veritabanı bilgilerini güncelleyin.
 3. `php -S localhost:8000` ile yerel ortamda test edin.
+
+## Sağlayıcı Entegrasyonu
+
+Admin panelinde **Ürün & Stok → Sağlayıcılar** bölümünü kullanarak Lotus Lisans API bilgilerinizi kaydedebilir, bağlantı testi yapabilir ve sağlayıcı ürünlerini panelinize aktarabilirsiniz. Entegrasyon akışı şu adımlardan oluşur:
+
+1. Sağlayıcı adı, temel API adresi ve API anahtarını girerek kaydedin.
+2. "API Testi Yap" butonu ile bağlantıyı doğrulayın.
+3. "Ürünleri Getir" seçeneği ile sağlayıcı kataloğunu listeleyin.
+4. Her bir ürün için kategori seçerek "İçe Aktar" butonu ile ürünü sitenize ekleyin veya güncelleyin.
+
+Postman üzerinden hızlı testler yapmak için `integrations/postman/lotus-provider.postman_collection.json` koleksiyonunu içeri aktarabilirsiniz. Koleksiyonda kullanıcı bilgisi, ürün listesi ve sipariş oluşturma uç noktaları örnek olarak yapılandırılmıştır.

--- a/admin/providers.php
+++ b/admin/providers.php
@@ -1,0 +1,463 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+use App\AuditLog;
+use App\Auth;
+use App\Database;
+use App\Helpers;
+use App\Services\ProviderIntegrationService;
+
+Auth::requireRoles(array('super_admin', 'admin'));
+
+$pdo = Database::connection();
+$service = new ProviderIntegrationService($pdo);
+$currentUser = $_SESSION['user'];
+
+$errors = array();
+$success = '';
+$testResult = null;
+$productsFetchResult = null;
+
+$providers = $service->listProviders();
+$selectedProviderId = isset($_GET['provider_id']) ? (int) $_GET['provider_id'] : 0;
+
+if ($selectedProviderId === 0 && $providers) {
+    $selectedProviderId = (int) $providers[0]['id'];
+}
+
+$selectedProvider = $selectedProviderId ? $service->findProvider($selectedProviderId) : null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = isset($_POST['action']) ? (string) $_POST['action'] : '';
+    $token = isset($_POST['csrf_token']) ? (string) $_POST['csrf_token'] : '';
+
+    if (!Helpers::verifyCsrf($token)) {
+        $errors[] = 'Geçersiz istek. Lütfen sayfayı yenileyip tekrar deneyin.';
+    } else {
+        if ($action === 'create_provider') {
+            $name = isset($_POST['name']) ? trim((string) $_POST['name']) : '';
+            $baseUrl = isset($_POST['base_url']) ? trim((string) $_POST['base_url']) : '';
+            $apiKey = isset($_POST['api_key']) ? trim((string) $_POST['api_key']) : '';
+            $isActive = isset($_POST['is_active']);
+
+            if ($name === '' || $baseUrl === '' || $apiKey === '') {
+                $errors[] = 'Sağlayıcı adı, API adresi ve anahtar alanları zorunludur.';
+            }
+
+            if (!$errors) {
+                $providerId = $service->createProvider($name, $baseUrl, $apiKey, $isActive);
+                $success = 'Sağlayıcı eklendi.';
+                AuditLog::record(
+                    $currentUser['id'],
+                    'provider.create',
+                    'external_provider',
+                    $providerId,
+                    sprintf('Yeni sağlayıcı eklendi: %s', $name)
+                );
+
+                $selectedProviderId = $providerId;
+                $selectedProvider = $service->findProvider($selectedProviderId);
+                $providers = $service->listProviders();
+            }
+        } elseif ($action === 'update_provider') {
+            $providerId = isset($_POST['provider_id']) ? (int) $_POST['provider_id'] : 0;
+            $name = isset($_POST['name']) ? trim((string) $_POST['name']) : '';
+            $baseUrl = isset($_POST['base_url']) ? trim((string) $_POST['base_url']) : '';
+            $apiKey = isset($_POST['api_key']) ? trim((string) $_POST['api_key']) : '';
+            $isActive = isset($_POST['is_active']);
+
+            if ($providerId <= 0 || !$service->findProvider($providerId)) {
+                $errors[] = 'Seçili sağlayıcı bulunamadı.';
+            }
+
+            if ($name === '' || $baseUrl === '' || $apiKey === '') {
+                $errors[] = 'Sağlayıcı adı, API adresi ve anahtar alanları zorunludur.';
+            }
+
+            if (!$errors) {
+                $service->updateProvider($providerId, $name, $baseUrl, $apiKey, $isActive);
+                $success = 'Sağlayıcı güncellendi.';
+                AuditLog::record(
+                    $currentUser['id'],
+                    'provider.update',
+                    'external_provider',
+                    $providerId,
+                    sprintf('Sağlayıcı güncellendi: %s', $name)
+                );
+
+                $selectedProviderId = $providerId;
+                $selectedProvider = $service->findProvider($selectedProviderId);
+                $providers = $service->listProviders();
+            }
+        } elseif ($action === 'delete_provider') {
+            $providerId = isset($_POST['provider_id']) ? (int) $_POST['provider_id'] : 0;
+            if ($providerId > 0 && $service->findProvider($providerId)) {
+                $service->deleteProvider($providerId);
+                $success = 'Sağlayıcı silindi.';
+                AuditLog::record(
+                    $currentUser['id'],
+                    'provider.delete',
+                    'external_provider',
+                    $providerId,
+                    sprintf('Sağlayıcı silindi: #%d', $providerId)
+                );
+                $providers = $service->listProviders();
+                if ($selectedProviderId === $providerId) {
+                    $selectedProviderId = $providers ? (int) $providers[0]['id'] : 0;
+                    $selectedProvider = $selectedProviderId ? $service->findProvider($selectedProviderId) : null;
+                }
+            }
+        } elseif ($action === 'test_provider') {
+            $providerId = isset($_POST['provider_id']) ? (int) $_POST['provider_id'] : 0;
+            if ($providerId > 0) {
+                $selectedProviderId = $providerId;
+                $selectedProvider = $service->findProvider($selectedProviderId);
+                if ($selectedProvider) {
+                    $testResult = $service->testConnection($selectedProvider);
+                    $success = $testResult['success'] ? 'API bağlantısı başarılı.' : $success;
+                    if (!$testResult['success']) {
+                        $errors[] = $testResult['message'];
+                    }
+                } else {
+                    $errors[] = 'Sağlayıcı bulunamadı.';
+                }
+            }
+        } elseif ($action === 'fetch_products') {
+            $providerId = isset($_POST['provider_id']) ? (int) $_POST['provider_id'] : 0;
+            if ($providerId > 0) {
+                $selectedProviderId = $providerId;
+                $selectedProvider = $service->findProvider($selectedProviderId);
+                if ($selectedProvider) {
+                    $productsFetchResult = $service->fetchProducts($selectedProvider);
+                    if (!$productsFetchResult['success']) {
+                        $errors[] = $productsFetchResult['message'];
+                    } else {
+                        $success = 'Ürün listesi güncellendi.';
+                    }
+                } else {
+                    $errors[] = 'Sağlayıcı bulunamadı.';
+                }
+            }
+        } elseif ($action === 'import_product') {
+            $providerId = isset($_POST['provider_id']) ? (int) $_POST['provider_id'] : 0;
+            $remoteProductId = isset($_POST['remote_product_id']) ? trim((string) $_POST['remote_product_id']) : '';
+            $name = isset($_POST['product_name']) ? trim((string) $_POST['product_name']) : '';
+            $description = isset($_POST['product_description']) ? trim((string) $_POST['product_description']) : '';
+            $remoteAmount = isset($_POST['remote_amount']) ? trim((string) $_POST['remote_amount']) : '';
+            $categoryId = isset($_POST['category_id']) ? (int) $_POST['category_id'] : 0;
+
+            $selectedProviderId = $providerId;
+            $selectedProvider = $providerId > 0 ? $service->findProvider($providerId) : null;
+
+            if (!$selectedProvider) {
+                $errors[] = 'Sağlayıcı bulunamadı.';
+            }
+
+            $costSanitized = preg_replace('/[^0-9.,-]/', '', $remoteAmount);
+            $costSanitized = str_replace(',', '.', (string) $costSanitized);
+            $costPrice = $costSanitized !== '' ? (float) $costSanitized : 0.0;
+
+            if ($remoteProductId === '' || $name === '' || $categoryId <= 0 || $costPrice <= 0) {
+                $errors[] = 'Ürün adı, fiyatı ve kategori seçimi zorunludur.';
+            }
+
+            if (!$errors && $selectedProvider) {
+                $salePrice = Helpers::priceFromCostTry($costPrice);
+
+                $mapping = $service->findMapping($providerId, $remoteProductId);
+                $skuSuffix = preg_replace('/[^A-Za-z0-9_-]/', '', $remoteProductId);
+                if ($skuSuffix === '') {
+                    $skuSuffix = (string) $remoteProductId;
+                }
+                $sku = substr('EXT-' . $providerId . '-' . $skuSuffix, 0, 150);
+
+                if ($mapping) {
+                    $productId = (int) $mapping['product_id'];
+                    $stmt = $pdo->prepare('UPDATE products SET name = :name, category_id = :category_id, cost_price_try = :cost_price_try, price = :price, description = :description, updated_at = NOW() WHERE id = :id');
+                    $stmt->execute(array(
+                        'id' => $productId,
+                        'name' => $name,
+                        'category_id' => $categoryId,
+                        'cost_price_try' => $costPrice,
+                        'price' => $salePrice,
+                        'description' => $description !== '' ? $description : null,
+                    ));
+
+                    $service->saveMapping($providerId, $remoteProductId, $productId);
+                    $success = 'Ürün güncellendi.';
+
+                    AuditLog::record(
+                        $currentUser['id'],
+                        'provider.product_update',
+                        'product',
+                        $productId,
+                        sprintf('Sağlayıcı ürünü güncellendi: %s', $name)
+                    );
+                } else {
+                    $stmt = $pdo->prepare('INSERT INTO products (name, category_id, cost_price_try, price, description, sku, status, automatic_delivery, created_at) VALUES (:name, :category_id, :cost_price_try, :price, :description, :sku, :status, :automatic_delivery, NOW())');
+                    $stmt->execute(array(
+                        'name' => $name,
+                        'category_id' => $categoryId,
+                        'cost_price_try' => $costPrice,
+                        'price' => $salePrice,
+                        'description' => $description !== '' ? $description : null,
+                        'sku' => $sku,
+                        'status' => 'active',
+                        'automatic_delivery' => 0,
+                    ));
+
+                    $productId = (int) $pdo->lastInsertId();
+                    $service->saveMapping($providerId, $remoteProductId, $productId);
+                    $success = 'Ürün içe aktarıldı.';
+
+                    AuditLog::record(
+                        $currentUser['id'],
+                        'provider.product_import',
+                        'product',
+                        $productId,
+                        sprintf('Sağlayıcıdan ürün içe aktarıldı: %s', $name)
+                    );
+                }
+
+                $productsFetchResult = $service->fetchProducts($selectedProvider);
+            }
+        }
+    }
+}
+
+if (!$providers) {
+    $providers = $service->listProviders();
+}
+
+if (!$selectedProvider && $selectedProviderId) {
+    $selectedProvider = $service->findProvider($selectedProviderId);
+}
+
+$categories = array();
+try {
+    $stmt = $pdo->query('SELECT id, name FROM categories ORDER BY name ASC');
+    if ($stmt) {
+        $categories = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+} catch (\Throwable $exception) {
+    $categories = array();
+}
+
+$pageTitle = 'Sağlayıcılar';
+include __DIR__ . '/../templates/header.php';
+?>
+<div class="row g-4">
+    <div class="col-lg-4">
+        <div class="card border-0 shadow-sm mb-4">
+            <div class="card-header bg-white">
+                <h5 class="mb-0">Yeni Sağlayıcı</h5>
+            </div>
+            <div class="card-body">
+                <form method="post">
+                    <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                    <input type="hidden" name="action" value="create_provider">
+                    <div class="mb-3">
+                        <label class="form-label">Sağlayıcı Adı</label>
+                        <input type="text" name="name" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">API Adresi</label>
+                        <input type="url" name="base_url" class="form-control" placeholder="https://partner.lotuslisans.com.tr" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">API Anahtarı</label>
+                        <input type="text" name="api_key" class="form-control" required>
+                    </div>
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" name="is_active" id="create-provider-active" checked>
+                        <label class="form-check-label" for="create-provider-active">Aktif</label>
+                    </div>
+                    <div class="d-grid">
+                        <button type="submit" class="btn btn-primary">Sağlayıcı Ekle</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <div class="card border-0 shadow-sm">
+            <div class="card-header bg-white d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">Kayıtlı Sağlayıcılar</h5>
+            </div>
+            <div class="list-group list-group-flush">
+                <?php if (!$providers): ?>
+                    <div class="list-group-item">Henüz kayıtlı sağlayıcı yok.</div>
+                <?php else: ?>
+                    <?php foreach ($providers as $provider): ?>
+                        <?php $isActive = (int) $provider['is_active'] === 1; ?>
+                        <a href="<?= Helpers::sanitize(Helpers::urlWithQuery(array('provider_id' => (int) $provider['id']))) ?>"
+                           class="list-group-item list-group-item-action d-flex justify-content-between align-items-center <?= (int) $provider['id'] === $selectedProviderId ? 'active' : '' ?>">
+                            <span>
+                                <?= Helpers::sanitize($provider['name']) ?>
+                                <small class="d-block text-muted"><?= Helpers::sanitize($provider['base_url']) ?></small>
+                            </span>
+                            <span class="badge bg-<?= $isActive ? 'success' : 'secondary' ?>"><?= $isActive ? 'Aktif' : 'Pasif' ?></span>
+                        </a>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-8">
+        <div class="card border-0 shadow-sm">
+            <div class="card-header bg-white d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">Sağlayıcı Detayları</h5>
+                <?php if ($selectedProvider): ?>
+                    <small class="text-muted">Son test: <?= $selectedProvider['last_tested_at'] ? date('d.m.Y H:i', strtotime($selectedProvider['last_tested_at'])) : '—' ?></small>
+                <?php endif; ?>
+            </div>
+            <div class="card-body">
+                <?php if ($errors): ?>
+                    <div class="alert alert-danger">
+                        <ul class="mb-0">
+                            <?php foreach ($errors as $error): ?>
+                                <li><?= Helpers::sanitize($error) ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                <?php endif; ?>
+
+                <?php if ($success): ?>
+                    <div class="alert alert-success"><?= Helpers::sanitize($success) ?></div>
+                <?php endif; ?>
+
+                <?php if ($selectedProvider): ?>
+                    <form method="post" class="mb-4">
+                        <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                        <input type="hidden" name="action" value="update_provider">
+                        <input type="hidden" name="provider_id" value="<?= (int) $selectedProvider['id'] ?>">
+                        <div class="mb-3">
+                            <label class="form-label">Sağlayıcı Adı</label>
+                            <input type="text" name="name" class="form-control" value="<?= Helpers::sanitize($selectedProvider['name']) ?>" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">API Adresi</label>
+                            <input type="url" name="base_url" class="form-control" value="<?= Helpers::sanitize($selectedProvider['base_url']) ?>" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">API Anahtarı</label>
+                            <input type="text" name="api_key" class="form-control" value="<?= Helpers::sanitize($selectedProvider['api_key']) ?>" required>
+                        </div>
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" role="switch" name="is_active" id="provider-active" <?= (int) $selectedProvider['is_active'] === 1 ? 'checked' : '' ?>>
+                            <label class="form-check-label" for="provider-active">Aktif</label>
+                        </div>
+                        <div class="d-flex justify-content-end">
+                            <button type="submit" class="btn btn-primary">Kaydet</button>
+                        </div>
+                    </form>
+
+                    <div class="d-flex flex-wrap gap-2 justify-content-between align-items-center mb-4">
+                        <form method="post" class="d-inline" onsubmit="return confirm('Bu sağlayıcıyı silmek istediğinizden emin misiniz?');">
+                            <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                            <input type="hidden" name="action" value="delete_provider">
+                            <input type="hidden" name="provider_id" value="<?= (int) $selectedProvider['id'] ?>">
+                            <button type="submit" class="btn btn-outline-danger">Sil</button>
+                        </form>
+                        <div class="d-flex flex-wrap gap-2">
+                            <form method="post" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                                <input type="hidden" name="action" value="test_provider">
+                                <input type="hidden" name="provider_id" value="<?= (int) $selectedProvider['id'] ?>">
+                                <button type="submit" class="btn btn-outline-secondary">API Testi Yap</button>
+                            </form>
+                            <form method="post" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                                <input type="hidden" name="action" value="fetch_products">
+                                <input type="hidden" name="provider_id" value="<?= (int) $selectedProvider['id'] ?>">
+                                <button type="submit" class="btn btn-outline-primary">Ürünleri Getir</button>
+                            </form>
+                        </div>
+                    </div>
+
+                    <?php if ($testResult): ?>
+                        <div class="alert alert-<?= $testResult['success'] ? 'success' : 'danger' ?>">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <div>
+                                    <strong><?= Helpers::sanitize($testResult['message']) ?></strong>
+                                    <?php if (!empty($testResult['data'])): ?>
+                                        <pre class="small bg-light p-3 rounded mt-2 mb-0"><?= Helpers::sanitize(json_encode($testResult['data'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)) ?></pre>
+                                    <?php endif; ?>
+                                </div>
+                                <span class="badge bg-secondary">HTTP <?= (int) $testResult['status'] ?></span>
+                            </div>
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if ($productsFetchResult): ?>
+                        <?php if (!$productsFetchResult['success']): ?>
+                            <div class="alert alert-danger"><?= Helpers::sanitize($productsFetchResult['message']) ?></div>
+                        <?php else: ?>
+                            <div class="alert alert-info">Sağlayıcı ürünleri listelendi. İçe aktarmak istediğiniz ürünler için kategori seçip "İçe Aktar" butonuna basın.</div>
+                            <div class="table-responsive">
+                                <table class="table table-hover align-middle">
+                                    <thead>
+                                    <tr>
+                                        <th>ID</th>
+                                        <th>Başlık</th>
+                                        <th>Tutar (TRY)</th>
+                                        <th>Stok</th>
+                                        <th>Durum</th>
+                                        <th class="text-end">İşlemler</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <?php foreach ($productsFetchResult['data'] as $remoteProduct): ?>
+                                        <tr>
+                                            <td><?= Helpers::sanitize($remoteProduct['id']) ?></td>
+                                            <td>
+                                                <strong><?= Helpers::sanitize($remoteProduct['title']) ?></strong>
+                                                <?php if (!empty($remoteProduct['content'])): ?>
+                                                    <p class="small text-muted mb-0"><?= nl2br(Helpers::sanitize(mb_strimwidth($remoteProduct['content'], 0, 180, '…', 'UTF-8'))) ?></p>
+                                                <?php endif; ?>
+                                            </td>
+                                            <td><?= Helpers::sanitize($remoteProduct['amount']) ?></td>
+                                            <td><?= (int) $remoteProduct['stock'] ?></td>
+                                            <td>
+                                                <?php if ($remoteProduct['available']): ?>
+                                                    <span class="badge bg-success">Sipariş Verilebilir</span>
+                                                <?php else: ?>
+                                                    <span class="badge bg-secondary">Pasif</span>
+                                                <?php endif; ?>
+                                            </td>
+                                            <td class="text-end">
+                                                <?php if ($categories): ?>
+                                                    <form method="post" class="d-flex gap-2 align-items-center justify-content-end">
+                                                        <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                                                        <input type="hidden" name="action" value="import_product">
+                                                        <input type="hidden" name="provider_id" value="<?= (int) $selectedProvider['id'] ?>">
+                                                        <input type="hidden" name="remote_product_id" value="<?= Helpers::sanitize($remoteProduct['id']) ?>">
+                                                        <input type="hidden" name="product_name" value="<?= Helpers::sanitize($remoteProduct['title']) ?>">
+                                                        <input type="hidden" name="product_description" value="<?= Helpers::sanitize($remoteProduct['content']) ?>">
+                                                        <input type="hidden" name="remote_amount" value="<?= Helpers::sanitize($remoteProduct['amount']) ?>">
+                                                        <select name="category_id" class="form-select form-select-sm" required>
+                                                            <option value="">Kategori Seçin</option>
+                                                            <?php foreach ($categories as $category): ?>
+                                                                <option value="<?= (int) $category['id'] ?>"><?= Helpers::sanitize($category['name']) ?></option>
+                                                            <?php endforeach; ?>
+                                                        </select>
+                                                        <button type="submit" class="btn btn-sm btn-primary">İçe Aktar</button>
+                                                    </form>
+                                                <?php else: ?>
+                                                    <span class="text-muted small">Kategori oluşturmalısınız.</span>
+                                                <?php endif; ?>
+                                            </td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                    </tbody>
+                                </table>
+                            </div>
+                        <?php endif; ?>
+                    <?php endif; ?>
+                <?php else: ?>
+                    <p class="text-muted mb-0">Öncelikle sol taraftan bir sağlayıcı seçin veya oluşturun.</p>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>
+<?php
+include __DIR__ . '/../templates/footer.php';

--- a/admin/providers.php
+++ b/admin/providers.php
@@ -18,7 +18,22 @@ $success = '';
 $testResult = null;
 $productsFetchResult = null;
 
+$addError = static function (string $message) use (&$errors): void {
+    $message = trim($message);
+    if ($message === '') {
+        return;
+    }
+
+    if (!in_array($message, $errors, true)) {
+        $errors[] = $message;
+    }
+};
+
 $providers = $service->listProviders();
+$serviceError = $service->getLastError();
+if ($serviceError !== '') {
+    $addError($serviceError);
+}
 $selectedProviderId = isset($_GET['provider_id']) ? (int) $_GET['provider_id'] : 0;
 
 if ($selectedProviderId === 0 && $providers) {
@@ -46,18 +61,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             if (!$errors) {
                 $providerId = $service->createProvider($name, $baseUrl, $apiKey, $isActive);
-                $success = 'Sağlayıcı eklendi.';
-                AuditLog::record(
-                    $currentUser['id'],
-                    'provider.create',
-                    'external_provider',
-                    $providerId,
-                    sprintf('Yeni sağlayıcı eklendi: %s', $name)
-                );
+                if ($providerId > 0) {
+                    $success = 'Sağlayıcı eklendi.';
+                    AuditLog::record(
+                        $currentUser['id'],
+                        'provider.create',
+                        'external_provider',
+                        $providerId,
+                        sprintf('Yeni sağlayıcı eklendi: %s', $name)
+                    );
 
-                $selectedProviderId = $providerId;
-                $selectedProvider = $service->findProvider($selectedProviderId);
-                $providers = $service->listProviders();
+                    $selectedProviderId = $providerId;
+                    $selectedProvider = $service->findProvider($selectedProviderId);
+                    $providers = $service->listProviders();
+                } else {
+                    $addError($service->getLastError() ?: 'Sağlayıcı eklenemedi.');
+                }
             }
         } elseif ($action === 'update_provider') {
             $providerId = isset($_POST['provider_id']) ? (int) $_POST['provider_id'] : 0;
@@ -75,36 +94,42 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
 
             if (!$errors) {
-                $service->updateProvider($providerId, $name, $baseUrl, $apiKey, $isActive);
-                $success = 'Sağlayıcı güncellendi.';
-                AuditLog::record(
-                    $currentUser['id'],
-                    'provider.update',
-                    'external_provider',
-                    $providerId,
-                    sprintf('Sağlayıcı güncellendi: %s', $name)
-                );
+                if ($service->updateProvider($providerId, $name, $baseUrl, $apiKey, $isActive)) {
+                    $success = 'Sağlayıcı güncellendi.';
+                    AuditLog::record(
+                        $currentUser['id'],
+                        'provider.update',
+                        'external_provider',
+                        $providerId,
+                        sprintf('Sağlayıcı güncellendi: %s', $name)
+                    );
 
-                $selectedProviderId = $providerId;
-                $selectedProvider = $service->findProvider($selectedProviderId);
-                $providers = $service->listProviders();
+                    $selectedProviderId = $providerId;
+                    $selectedProvider = $service->findProvider($selectedProviderId);
+                    $providers = $service->listProviders();
+                } else {
+                    $addError($service->getLastError() ?: 'Sağlayıcı güncellenemedi.');
+                }
             }
         } elseif ($action === 'delete_provider') {
             $providerId = isset($_POST['provider_id']) ? (int) $_POST['provider_id'] : 0;
             if ($providerId > 0 && $service->findProvider($providerId)) {
-                $service->deleteProvider($providerId);
-                $success = 'Sağlayıcı silindi.';
-                AuditLog::record(
-                    $currentUser['id'],
-                    'provider.delete',
-                    'external_provider',
-                    $providerId,
-                    sprintf('Sağlayıcı silindi: #%d', $providerId)
-                );
-                $providers = $service->listProviders();
-                if ($selectedProviderId === $providerId) {
-                    $selectedProviderId = $providers ? (int) $providers[0]['id'] : 0;
-                    $selectedProvider = $selectedProviderId ? $service->findProvider($selectedProviderId) : null;
+                if ($service->deleteProvider($providerId)) {
+                    $success = 'Sağlayıcı silindi.';
+                    AuditLog::record(
+                        $currentUser['id'],
+                        'provider.delete',
+                        'external_provider',
+                        $providerId,
+                        sprintf('Sağlayıcı silindi: #%d', $providerId)
+                    );
+                    $providers = $service->listProviders();
+                    if ($selectedProviderId === $providerId) {
+                        $selectedProviderId = $providers ? (int) $providers[0]['id'] : 0;
+                        $selectedProvider = $selectedProviderId ? $service->findProvider($selectedProviderId) : null;
+                    }
+                } else {
+                    $addError($service->getLastError() ?: 'Sağlayıcı silinemedi.');
                 }
             }
         } elseif ($action === 'test_provider') {
@@ -112,6 +137,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($providerId > 0) {
                 $selectedProviderId = $providerId;
                 $selectedProvider = $service->findProvider($selectedProviderId);
+                $serviceError = $service->getLastError();
+                if ($serviceError !== '') {
+                    $addError($serviceError);
+                }
                 if ($selectedProvider) {
                     $testResult = $service->testConnection($selectedProvider);
                     $success = $testResult['success'] ? 'API bağlantısı başarılı.' : $success;
@@ -127,6 +156,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($providerId > 0) {
                 $selectedProviderId = $providerId;
                 $selectedProvider = $service->findProvider($selectedProviderId);
+                $serviceError = $service->getLastError();
+                if ($serviceError !== '') {
+                    $addError($serviceError);
+                }
                 if ($selectedProvider) {
                     $productsFetchResult = $service->fetchProducts($selectedProvider);
                     if (!$productsFetchResult['success']) {
@@ -148,6 +181,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             $selectedProviderId = $providerId;
             $selectedProvider = $providerId > 0 ? $service->findProvider($providerId) : null;
+            $serviceError = $service->getLastError();
+            if ($serviceError !== '') {
+                $addError($serviceError);
+            }
 
             if (!$selectedProvider) {
                 $errors[] = 'Sağlayıcı bulunamadı.';
@@ -227,10 +264,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 if (!$providers) {
     $providers = $service->listProviders();
+    $serviceError = $service->getLastError();
+    if ($serviceError !== '') {
+        $addError($serviceError);
+    }
 }
 
 if (!$selectedProvider && $selectedProviderId) {
     $selectedProvider = $service->findProvider($selectedProviderId);
+    $serviceError = $service->getLastError();
+    if ($serviceError !== '') {
+        $addError($serviceError);
+    }
 }
 
 $categories = array();
@@ -245,6 +290,20 @@ try {
 
 $pageTitle = 'Sağlayıcılar';
 include __DIR__ . '/../templates/header.php';
+?>
+
+<?php
+$truncateContent = static function (string $text): string {
+    if ($text === '') {
+        return '';
+    }
+
+    if (function_exists('mb_strimwidth')) {
+        return mb_strimwidth($text, 0, 180, '…', 'UTF-8');
+    }
+
+    return rtrim(substr($text, 0, 180)) . '…';
+};
 ?>
 <div class="row g-4">
     <div class="col-lg-4">
@@ -411,7 +470,7 @@ include __DIR__ . '/../templates/header.php';
                                             <td>
                                                 <strong><?= Helpers::sanitize($remoteProduct['title']) ?></strong>
                                                 <?php if (!empty($remoteProduct['content'])): ?>
-                                                    <p class="small text-muted mb-0"><?= nl2br(Helpers::sanitize(mb_strimwidth($remoteProduct['content'], 0, 180, '…', 'UTF-8'))) ?></p>
+                                                    <p class="small text-muted mb-0"><?= nl2br(Helpers::sanitize($truncateContent((string) $remoteProduct['content']))) ?></p>
                                                 <?php endif; ?>
                                             </td>
                                             <td><?= Helpers::sanitize($remoteProduct['amount']) ?></td>

--- a/app/Services/ProviderIntegrationService.php
+++ b/app/Services/ProviderIntegrationService.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace App\Services;
+
+use PDO;
+use PDOException;
+
+class ProviderIntegrationService
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function listProviders(): array
+    {
+        $stmt = $this->pdo->query('SELECT * FROM external_providers ORDER BY name ASC');
+        return $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : array();
+    }
+
+    /**
+     * @param int $id
+     * @return array<string,mixed>|null
+     */
+    public function findProvider(int $id): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM external_providers WHERE id = :id');
+        $stmt->execute(array('id' => $id));
+        $provider = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $provider ?: null;
+    }
+
+    /**
+     * @param string $name
+     * @param string $baseUrl
+     * @param string $apiKey
+     * @param bool $isActive
+     * @return int
+     */
+    public function createProvider(string $name, string $baseUrl, string $apiKey, bool $isActive): int
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO external_providers (name, base_url, api_key, is_active, created_at) VALUES (:name, :base_url, :api_key, :is_active, NOW())');
+        $stmt->execute(array(
+            'name' => $name,
+            'base_url' => $baseUrl,
+            'api_key' => $apiKey,
+            'is_active' => $isActive ? 1 : 0,
+        ));
+
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    /**
+     * @param int $id
+     * @param string $name
+     * @param string $baseUrl
+     * @param string $apiKey
+     * @param bool $isActive
+     * @return bool
+     */
+    public function updateProvider(int $id, string $name, string $baseUrl, string $apiKey, bool $isActive): bool
+    {
+        $stmt = $this->pdo->prepare('UPDATE external_providers SET name = :name, base_url = :base_url, api_key = :api_key, is_active = :is_active, updated_at = NOW() WHERE id = :id');
+        return $stmt->execute(array(
+            'id' => $id,
+            'name' => $name,
+            'base_url' => $baseUrl,
+            'api_key' => $apiKey,
+            'is_active' => $isActive ? 1 : 0,
+        ));
+    }
+
+    /**
+     * @param int $id
+     * @return bool
+     */
+    public function deleteProvider(int $id): bool
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM external_providers WHERE id = :id');
+        return $stmt->execute(array('id' => $id));
+    }
+
+    /**
+     * @param array<string,mixed> $provider
+     * @return array<string,mixed>
+     */
+    public function testConnection(array $provider): array
+    {
+        $response = $this->sendRequest($provider, 'GET', 'api/user', array('apikey' => $provider['api_key']));
+
+        if ($response['error'] !== null) {
+            $this->storeTestResult((int) $provider['id'], 0, $response['error']);
+
+            return array(
+                'success' => false,
+                'status' => 0,
+                'message' => 'API isteği gönderilemedi: ' . $response['error'],
+                'data' => array(),
+            );
+        }
+
+        $statusCode = $response['status'];
+        $body = $response['body'];
+        $data = json_decode($body, true);
+
+        $message = $statusCode === 200 ? 'API bağlantısı başarılı.' : sprintf('API bağlantısı başarısız (HTTP %d).', $statusCode);
+
+        $this->storeTestResult((int) $provider['id'], $statusCode, $body);
+
+        return array(
+            'success' => $statusCode === 200,
+            'status' => $statusCode,
+            'message' => $message,
+            'data' => is_array($data) ? $data : array(),
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $provider
+     * @return array<int,array<string,mixed>>|array<string,mixed>
+     */
+    public function fetchProducts(array $provider)
+    {
+        $response = $this->sendRequest($provider, 'GET', 'api/products', array('apikey' => $provider['api_key']));
+
+        if ($response['error'] !== null) {
+            return array(
+                'success' => false,
+                'status' => 0,
+                'message' => 'Ürün listesi alınamadı: ' . $response['error'],
+                'data' => array(),
+            );
+        }
+
+        $statusCode = $response['status'];
+        $body = $response['body'];
+        $json = json_decode($body, true);
+
+        if ($statusCode !== 200 || !is_array($json)) {
+            return array(
+                'success' => false,
+                'status' => $statusCode,
+                'message' => $statusCode === 0 ? 'API yanıtı alınamadı.' : sprintf('Beklenmeyen yanıt (HTTP %d).', $statusCode),
+                'data' => array(),
+            );
+        }
+
+        $items = array();
+        if (isset($json['data']) && is_array($json['data'])) {
+            foreach ($json['data'] as $product) {
+                if (!is_array($product)) {
+                    continue;
+                }
+
+                $items[] = array(
+                    'id' => isset($product['id']) ? (string) $product['id'] : '',
+                    'title' => isset($product['title']) ? (string) $product['title'] : '',
+                    'content' => isset($product['content']) ? (string) $product['content'] : '',
+                    'amount' => isset($product['amount']) ? (string) $product['amount'] : '0',
+                    'stock' => isset($product['stock']) ? (int) $product['stock'] : 0,
+                    'available' => isset($product['available']) ? (bool) $product['available'] : false,
+                );
+            }
+        }
+
+        return array(
+            'success' => (bool)($json['success'] ?? false),
+            'status' => $statusCode,
+            'message' => isset($json['message']) ? (string) $json['message'] : 'Ürünler alındı.',
+            'data' => $items,
+        );
+    }
+
+    /**
+     * @param int $providerId
+     * @param string $remoteProductId
+     * @return array<string,mixed>|null
+     */
+    public function findMapping(int $providerId, string $remoteProductId): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM external_provider_products WHERE provider_id = :provider_id AND provider_product_id = :remote_id');
+        $stmt->execute(array('provider_id' => $providerId, 'remote_id' => $remoteProductId));
+
+        $mapping = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $mapping ?: null;
+    }
+
+    /**
+     * @param int $providerId
+     * @param string $remoteProductId
+     * @param int $productId
+     * @return void
+     */
+    public function saveMapping(int $providerId, string $remoteProductId, int $productId): void
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO external_provider_products (provider_id, provider_product_id, product_id, created_at, updated_at) VALUES (:provider_id, :remote_id, :product_id, NOW(), NOW())
+            ON DUPLICATE KEY UPDATE product_id = VALUES(product_id), updated_at = NOW()');
+        $stmt->execute(array(
+            'provider_id' => $providerId,
+            'remote_id' => $remoteProductId,
+            'product_id' => $productId,
+        ));
+    }
+
+    /**
+     * @param array<string,mixed> $provider
+     * @param string $method
+     * @param string $path
+     * @param array<string,mixed> $query
+     * @param array<string,mixed>|null $payload
+     * @return array{status:int,body:string,error:?string}
+     */
+    private function sendRequest(array $provider, string $method, string $path, array $query = array(), ?array $payload = null): array
+    {
+        $baseUrl = isset($provider['base_url']) ? (string) $provider['base_url'] : '';
+        $baseUrl = trim($baseUrl);
+
+        if ($baseUrl === '') {
+            $baseUrl = 'https://partner.lotuslisans.com.tr';
+        }
+
+        $baseUrl = rtrim($baseUrl, '/') . '/';
+        $url = $baseUrl . ltrim($path, '/');
+
+        if ($query) {
+            $separator = strpos($url, '?') === false ? '?' : '&';
+            $url .= $separator . http_build_query($query);
+        }
+
+        $headers = $this->buildAuthHeaders($provider);
+        $headerLines = array();
+        foreach ($headers as $key => $value) {
+            $headerLines[] = $key . ': ' . $value;
+        }
+
+        if ($payload !== null) {
+            $headerLines[] = 'Content-Type: application/json';
+        }
+
+        $handle = curl_init($url);
+        if ($handle === false) {
+            return array('status' => 0, 'body' => '', 'error' => 'İstek başlatılamadı.');
+        }
+
+        curl_setopt($handle, CURLOPT_CUSTOMREQUEST, strtoupper($method));
+        curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handle, CURLOPT_TIMEOUT, 20);
+        curl_setopt($handle, CURLOPT_HTTPHEADER, $headerLines);
+        curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, 0);
+
+        if ($payload !== null) {
+            $json = json_encode($payload, JSON_UNESCAPED_UNICODE);
+            if ($json === false) {
+                curl_close($handle);
+                return array('status' => 0, 'body' => '', 'error' => 'İstek verisi kodlanamadı.');
+            }
+            curl_setopt($handle, CURLOPT_POSTFIELDS, $json);
+        }
+
+        $body = curl_exec($handle);
+        $status = (int) curl_getinfo($handle, CURLINFO_RESPONSE_CODE);
+        $error = null;
+
+        if ($body === false) {
+            $error = curl_error($handle);
+        }
+
+        curl_close($handle);
+
+        return array(
+            'status' => $status,
+            'body' => $body !== false ? $body : '',
+            'error' => $error,
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $provider
+     * @return array<string,string>
+     */
+    private function buildAuthHeaders(array $provider): array
+    {
+        $apiKey = isset($provider['api_key']) ? (string) $provider['api_key'] : '';
+        return array(
+            'Accept' => 'application/json',
+            'X-API-Key' => $apiKey,
+            'User-Agent' => 'LotusProviderIntegration/1.0',
+        );
+    }
+
+    private function storeTestResult(int $providerId, int $status, string $response): void
+    {
+        try {
+            $stmt = $this->pdo->prepare('UPDATE external_providers SET last_tested_at = NOW(), last_test_response = :response, updated_at = NOW() WHERE id = :id');
+            $stmt->execute(array(
+                'id' => $providerId,
+                'response' => $response !== '' ? mb_substr($response, 0, 1000) : null,
+            ));
+        } catch (PDOException $exception) {
+            error_log('[ProviderIntegrationService] Test sonucu kaydedilemedi: ' . $exception->getMessage());
+        }
+    }
+}

--- a/app/Services/ProviderIntegrationService.php
+++ b/app/Services/ProviderIntegrationService.php
@@ -2,16 +2,66 @@
 
 namespace App\Services;
 
+use App\Migrations\Schema;
 use PDO;
 use PDOException;
+use Throwable;
 
 class ProviderIntegrationService
 {
     private PDO $pdo;
+    private bool $schemaEnsured = false;
+    private ?string $lastError = null;
 
     public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
+        $this->ensureStorage();
+    }
+
+    public function getLastError(): string
+    {
+        return $this->lastError ?? '';
+    }
+
+    private function setLastError(?string $message): void
+    {
+        $this->lastError = $message !== null ? (string) $message : null;
+    }
+
+    private function ensureStorage(): void
+    {
+        if ($this->schemaEnsured) {
+            return;
+        }
+
+        $this->schemaEnsured = true;
+
+        if (!class_exists(Schema::class)) {
+            return;
+        }
+
+        try {
+            Schema::ensure();
+        } catch (Throwable $exception) {
+            $this->schemaEnsured = false;
+            $this->setLastError('Sağlayıcı tabloları hazırlanırken bir hata oluştu. Lütfen sistem yöneticiniz ile görüşün.');
+            error_log('[ProviderIntegrationService] Schema ensure failed: ' . $exception->getMessage());
+        }
+    }
+
+    private function handleStorageException(PDOException $exception): void
+    {
+        $this->schemaEnsured = false;
+
+        $message = $exception->getMessage();
+        if (stripos($message, 'external_providers') !== false || stripos($message, 'external_provider_products') !== false) {
+            $this->setLastError('Sağlayıcı veritabanı tabloları bulunamadı veya oluşturulamadı. Lütfen şema güncellemelerini çalıştırın.');
+        } else {
+            $this->setLastError('Veritabanı işlemi sırasında bir hata oluştu. Ayrıntılar loglara yazıldı.');
+        }
+
+        error_log('[ProviderIntegrationService] Storage error: ' . $message);
     }
 
     /**
@@ -19,7 +69,17 @@ class ProviderIntegrationService
      */
     public function listProviders(): array
     {
-        $stmt = $this->pdo->query('SELECT * FROM external_providers ORDER BY name ASC');
+        $this->ensureStorage();
+
+        try {
+            $stmt = $this->pdo->query('SELECT * FROM external_providers ORDER BY name ASC');
+        } catch (PDOException $exception) {
+            $this->handleStorageException($exception);
+            return array();
+        }
+
+        $this->setLastError(null);
+
         return $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : array();
     }
 
@@ -29,9 +89,18 @@ class ProviderIntegrationService
      */
     public function findProvider(int $id): ?array
     {
-        $stmt = $this->pdo->prepare('SELECT * FROM external_providers WHERE id = :id');
-        $stmt->execute(array('id' => $id));
-        $provider = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->ensureStorage();
+
+        try {
+            $stmt = $this->pdo->prepare('SELECT * FROM external_providers WHERE id = :id');
+            $stmt->execute(array('id' => $id));
+            $provider = $stmt->fetch(PDO::FETCH_ASSOC);
+        } catch (PDOException $exception) {
+            $this->handleStorageException($exception);
+            return null;
+        }
+
+        $this->setLastError(null);
 
         return $provider ?: null;
     }
@@ -45,13 +114,22 @@ class ProviderIntegrationService
      */
     public function createProvider(string $name, string $baseUrl, string $apiKey, bool $isActive): int
     {
-        $stmt = $this->pdo->prepare('INSERT INTO external_providers (name, base_url, api_key, is_active, created_at) VALUES (:name, :base_url, :api_key, :is_active, NOW())');
-        $stmt->execute(array(
-            'name' => $name,
-            'base_url' => $baseUrl,
-            'api_key' => $apiKey,
-            'is_active' => $isActive ? 1 : 0,
-        ));
+        $this->ensureStorage();
+
+        try {
+            $stmt = $this->pdo->prepare('INSERT INTO external_providers (name, base_url, api_key, is_active, created_at) VALUES (:name, :base_url, :api_key, :is_active, NOW())');
+            $stmt->execute(array(
+                'name' => $name,
+                'base_url' => $baseUrl,
+                'api_key' => $apiKey,
+                'is_active' => $isActive ? 1 : 0,
+            ));
+        } catch (PDOException $exception) {
+            $this->handleStorageException($exception);
+            return 0;
+        }
+
+        $this->setLastError(null);
 
         return (int) $this->pdo->lastInsertId();
     }
@@ -66,14 +144,25 @@ class ProviderIntegrationService
      */
     public function updateProvider(int $id, string $name, string $baseUrl, string $apiKey, bool $isActive): bool
     {
-        $stmt = $this->pdo->prepare('UPDATE external_providers SET name = :name, base_url = :base_url, api_key = :api_key, is_active = :is_active, updated_at = NOW() WHERE id = :id');
-        return $stmt->execute(array(
-            'id' => $id,
-            'name' => $name,
-            'base_url' => $baseUrl,
-            'api_key' => $apiKey,
-            'is_active' => $isActive ? 1 : 0,
-        ));
+        $this->ensureStorage();
+
+        try {
+            $stmt = $this->pdo->prepare('UPDATE external_providers SET name = :name, base_url = :base_url, api_key = :api_key, is_active = :is_active, updated_at = NOW() WHERE id = :id');
+            $result = $stmt->execute(array(
+                'id' => $id,
+                'name' => $name,
+                'base_url' => $baseUrl,
+                'api_key' => $apiKey,
+                'is_active' => $isActive ? 1 : 0,
+            ));
+        } catch (PDOException $exception) {
+            $this->handleStorageException($exception);
+            return false;
+        }
+
+        $this->setLastError(null);
+
+        return (bool) $result;
     }
 
     /**
@@ -82,8 +171,19 @@ class ProviderIntegrationService
      */
     public function deleteProvider(int $id): bool
     {
-        $stmt = $this->pdo->prepare('DELETE FROM external_providers WHERE id = :id');
-        return $stmt->execute(array('id' => $id));
+        $this->ensureStorage();
+
+        try {
+            $stmt = $this->pdo->prepare('DELETE FROM external_providers WHERE id = :id');
+            $result = $stmt->execute(array('id' => $id));
+        } catch (PDOException $exception) {
+            $this->handleStorageException($exception);
+            return false;
+        }
+
+        $this->setLastError(null);
+
+        return (bool) $result;
     }
 
     /**
@@ -92,6 +192,7 @@ class ProviderIntegrationService
      */
     public function testConnection(array $provider): array
     {
+        $this->setLastError(null);
         $response = $this->sendRequest($provider, 'GET', 'api/user', array('apikey' => $provider['api_key']));
 
         if ($response['error'] !== null) {
@@ -127,6 +228,7 @@ class ProviderIntegrationService
      */
     public function fetchProducts(array $provider)
     {
+        $this->setLastError(null);
         $response = $this->sendRequest($provider, 'GET', 'api/products', array('apikey' => $provider['api_key']));
 
         if ($response['error'] !== null) {
@@ -184,10 +286,18 @@ class ProviderIntegrationService
      */
     public function findMapping(int $providerId, string $remoteProductId): ?array
     {
-        $stmt = $this->pdo->prepare('SELECT * FROM external_provider_products WHERE provider_id = :provider_id AND provider_product_id = :remote_id');
-        $stmt->execute(array('provider_id' => $providerId, 'remote_id' => $remoteProductId));
+        $this->ensureStorage();
 
-        $mapping = $stmt->fetch(PDO::FETCH_ASSOC);
+        try {
+            $stmt = $this->pdo->prepare('SELECT * FROM external_provider_products WHERE provider_id = :provider_id AND provider_product_id = :remote_id');
+            $stmt->execute(array('provider_id' => $providerId, 'remote_id' => $remoteProductId));
+            $mapping = $stmt->fetch(PDO::FETCH_ASSOC);
+        } catch (PDOException $exception) {
+            $this->handleStorageException($exception);
+            return null;
+        }
+
+        $this->setLastError(null);
 
         return $mapping ?: null;
     }
@@ -200,13 +310,20 @@ class ProviderIntegrationService
      */
     public function saveMapping(int $providerId, string $remoteProductId, int $productId): void
     {
-        $stmt = $this->pdo->prepare('INSERT INTO external_provider_products (provider_id, provider_product_id, product_id, created_at, updated_at) VALUES (:provider_id, :remote_id, :product_id, NOW(), NOW())
+        $this->ensureStorage();
+
+        try {
+            $stmt = $this->pdo->prepare('INSERT INTO external_provider_products (provider_id, provider_product_id, product_id, created_at, updated_at) VALUES (:provider_id, :remote_id, :product_id, NOW(), NOW())
             ON DUPLICATE KEY UPDATE product_id = VALUES(product_id), updated_at = NOW()');
-        $stmt->execute(array(
-            'provider_id' => $providerId,
-            'remote_id' => $remoteProductId,
-            'product_id' => $productId,
-        ));
+            $stmt->execute(array(
+                'provider_id' => $providerId,
+                'remote_id' => $remoteProductId,
+                'product_id' => $productId,
+            ));
+            $this->setLastError(null);
+        } catch (PDOException $exception) {
+            $this->handleStorageException($exception);
+        }
     }
 
     /**
@@ -219,6 +336,10 @@ class ProviderIntegrationService
      */
     private function sendRequest(array $provider, string $method, string $path, array $query = array(), ?array $payload = null): array
     {
+        if (!function_exists('curl_init')) {
+            return array('status' => 0, 'body' => '', 'error' => 'Sunucuda cURL eklentisi etkin değil.');
+        }
+
         $baseUrl = isset($provider['base_url']) ? (string) $provider['base_url'] : '';
         $baseUrl = trim($baseUrl);
 
@@ -298,14 +419,29 @@ class ProviderIntegrationService
 
     private function storeTestResult(int $providerId, int $status, string $response): void
     {
+        $this->ensureStorage();
+
         try {
             $stmt = $this->pdo->prepare('UPDATE external_providers SET last_tested_at = NOW(), last_test_response = :response, updated_at = NOW() WHERE id = :id');
             $stmt->execute(array(
                 'id' => $providerId,
-                'response' => $response !== '' ? mb_substr($response, 0, 1000) : null,
+                'response' => $this->truncateResponse($response),
             ));
         } catch (PDOException $exception) {
             error_log('[ProviderIntegrationService] Test sonucu kaydedilemedi: ' . $exception->getMessage());
         }
+    }
+
+    private function truncateResponse(string $response): ?string
+    {
+        if ($response === '') {
+            return null;
+        }
+
+        if (function_exists('mb_substr')) {
+            return mb_substr($response, 0, 1000);
+        }
+
+        return substr($response, 0, 1000);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "type": "project",
   "require": {
     "php": "^8.1",
-    "guzzlehttp/guzzle": "^7.9",
     "vlucas/phpdotenv": "^5.6"
   },
   "autoload": {

--- a/integrations/postman/lotus-provider.postman_collection.json
+++ b/integrations/postman/lotus-provider.postman_collection.json
@@ -1,0 +1,132 @@
+{
+  "info": {
+    "name": "Lotus Lisans Sağlayıcı API",
+    "description": "Lotus Lisans sağlayıcı entegrasyonu için temel API istekleri.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "version": {
+      "major": 1,
+      "minor": 0,
+      "patch": 0
+    }
+  },
+  "item": [
+    {
+      "name": "Kullanıcı Bilgisi",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "X-API-Key",
+            "value": "{{api_key}}"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/user?apikey={{api_key}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "user"
+          ],
+          "query": [
+            {
+              "key": "apikey",
+              "value": "{{api_key}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Ürün Listesi",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "X-API-Key",
+            "value": "{{api_key}}"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/products?apikey={{api_key}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "products"
+          ],
+          "query": [
+            {
+              "key": "apikey",
+              "value": "{{api_key}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Sipariş Oluştur",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-API-Key",
+            "value": "{{api_key}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"product_id\": {{product_id}},\n  \"note\": \"müşteri notu\"\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/api/orders?apikey={{api_key}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "orders"
+          ],
+          "query": [
+            {
+              "key": "apikey",
+              "value": "{{api_key}}"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://partner.lotuslisans.com.tr"
+    },
+    {
+      "key": "api_key",
+      "value": "TEST_KEY"
+    },
+    {
+      "key": "product_id",
+      "value": "57"
+    }
+  ]
+}

--- a/schema.sql
+++ b/schema.sql
@@ -172,6 +172,31 @@ CREATE TABLE IF NOT EXISTS product_orders (
     INDEX idx_product_orders_external (external_reference)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS external_providers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    base_url VARCHAR(255) NOT NULL,
+    api_key VARCHAR(191) NOT NULL,
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    last_tested_at DATETIME NULL,
+    last_test_response TEXT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS external_provider_products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    provider_id INT NOT NULL,
+    provider_product_id VARCHAR(100) NOT NULL,
+    product_id INT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_external_provider_product (provider_id, provider_product_id),
+    UNIQUE KEY uniq_external_provider_local (product_id),
+    CONSTRAINT fk_external_provider_product_provider FOREIGN KEY (provider_id) REFERENCES external_providers(id) ON DELETE CASCADE,
+    CONSTRAINT fk_external_provider_product_product FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS support_tickets (
     id INT AUTO_INCREMENT PRIMARY KEY,
     user_id INT NOT NULL,

--- a/src/Migrations/Schema.php
+++ b/src/Migrations/Schema.php
@@ -23,6 +23,8 @@ final class Schema
         self::ensureProductsTable($pdo);
         self::ensureProductStockTable($pdo);
         self::ensureProductOrdersTable($pdo);
+        self::ensureExternalProvidersTable($pdo);
+        self::ensureExternalProviderProductsTable($pdo);
         self::ensureResellerFavoritesTable($pdo);
         self::ensureStockWatchersTable($pdo);
         self::ensureAutoTopupTable($pdo);
@@ -201,6 +203,44 @@ final class Schema
         self::addIndex($pdo, 'product_orders', 'idx_product_orders_user_created', 'ADD INDEX idx_product_orders_user_created (user_id, created_at)');
         self::addIndex($pdo, 'product_orders', 'idx_product_orders_status', 'ADD INDEX idx_product_orders_status (status)');
         self::addIndex($pdo, 'product_orders', 'idx_product_orders_external', 'ADD INDEX idx_product_orders_external (external_reference)');
+    }
+
+    private static function ensureExternalProvidersTable(PDO $pdo): void
+    {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS external_providers (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(150) NOT NULL,
+            base_url VARCHAR(255) NOT NULL,
+            api_key VARCHAR(191) NOT NULL,
+            is_active TINYINT(1) NOT NULL DEFAULT 1,
+            last_tested_at DATETIME NULL,
+            last_test_response TEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        self::ensureColumn($pdo, 'external_providers', 'is_active', 'TINYINT(1) NOT NULL DEFAULT 1');
+        self::ensureColumn($pdo, 'external_providers', 'last_tested_at', 'DATETIME NULL');
+        self::ensureColumn($pdo, 'external_providers', 'last_test_response', 'TEXT NULL');
+    }
+
+    private static function ensureExternalProviderProductsTable(PDO $pdo): void
+    {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS external_provider_products (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            provider_id INT NOT NULL,
+            provider_product_id VARCHAR(100) NOT NULL,
+            product_id INT NOT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uniq_external_provider_product (provider_id, provider_product_id),
+            UNIQUE KEY uniq_external_provider_local (product_id),
+            CONSTRAINT fk_external_provider_product_provider FOREIGN KEY (provider_id) REFERENCES external_providers(id) ON DELETE CASCADE,
+            CONSTRAINT fk_external_provider_product_product FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        self::addIndex($pdo, 'external_provider_products', 'uniq_external_provider_product', 'ADD UNIQUE INDEX uniq_external_provider_product (provider_id, provider_product_id)');
+        self::addIndex($pdo, 'external_provider_products', 'uniq_external_provider_local', 'ADD UNIQUE INDEX uniq_external_provider_local (product_id)');
     }
 
     private static function ensureResellerFavoritesTable(PDO $pdo): void

--- a/templates/header.php
+++ b/templates/header.php
@@ -148,6 +148,7 @@ if ($user) {
                     array('label' => 'Ürünler', 'href' => '/admin/products.php', 'pattern' => '/admin/products.php', 'icon' => 'bi-box', 'roles' => array('super_admin', 'admin', 'content')),
                     array('label' => 'Stok Yönetimi', 'href' => '/admin/product-stock.php', 'pattern' => '/admin/product-stock.php', 'icon' => 'bi-archive', 'roles' => array('super_admin', 'admin', 'content')),
                     array('label' => 'Kategoriler', 'href' => '/admin/categories.php', 'pattern' => '/admin/categories.php', 'icon' => 'bi-diagram-3', 'roles' => array('super_admin', 'admin', 'content')),
+                    array('label' => 'Sağlayıcılar', 'href' => '/admin/providers.php', 'pattern' => '/admin/providers.php', 'icon' => 'bi-cloud-arrow-down', 'roles' => array('super_admin', 'admin')),
                 ),
             ),
             array(


### PR DESCRIPTION
## Summary
- replace the provider integration HTTP calls with a native cURL-based implementation to avoid missing dependency fatals
- ensure API test failures surface clear error messages and still persist last responses for diagnostics
- drop the unused Guzzle requirement from composer.json so the panel works without Composer-installed vendors

## Testing
- php -l admin/providers.php
- php -l app/Services/ProviderIntegrationService.php

------
https://chatgpt.com/codex/tasks/task_b_68e52a82fef08321a0e59cf56e32f599