### PR TITLE
Align header layout with responsive navbar behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor/
 .DS_Store
 storage/
+uploads/
+logs/

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Bu depo, ePin, lisans ve dijital hesap satış süreçlerini yönetmek için gel
 1. `composer install`
 2. `cp config/config.sample.php config/config.php` ve veritabanı bilgilerini güncelleyin.
 3. `php -S localhost:8000` ile yerel ortamda test edin.
+
+## Entegrasyonlar
+
+Sistem, kendi ürün ve stok yönetiminiz için tasarlanmıştır. Harici sağlayıcı bağlantıları bu sürümde bulunmamaktadır.

--- a/admin/.gitignore
+++ b/admin/.gitignore
@@ -1,0 +1,1 @@
+error.log

--- a/admin/product-stock.php
+++ b/admin/product-stock.php
@@ -213,8 +213,19 @@ if ($productId > 0) {
                                 <tbody>
                                 <?php foreach ($items as $item): ?>
                                     <tr>
-                                        <td><?= (int) $item['id'] ?></td>
-                                        <td class="font-monospace small"><?= nl2br(Helpers::sanitize($item['content'])) ?></td>
+                                        <td>
+                                            <?php if (isset($item['id'])): ?>
+                                                <?= (int) $item['id'] ?>
+                                            <?php else: ?>
+                                                -
+                                            <?php endif; ?>
+                                        </td>
+                                        <td class="font-monospace small">
+                                            <?php
+                                            $content = isset($item['content']) ? (string) $item['content'] : '';
+                                            echo nl2br(Helpers::sanitize($content));
+                                            ?>
+                                        </td>
                                         <td>
                                             <?php
                                             $badgeMap = array(
@@ -276,7 +287,12 @@ if ($productId > 0) {
     exit;
 }
 
-$list = $pdo->query('SELECT pr.id, pr.name, cat.name AS category_name, (SELECT COUNT(*) FROM product_stock_items psi WHERE psi.product_id = pr.id AND psi.status = "available") AS available_stock, (SELECT COUNT(*) FROM product_stock_items psi WHERE psi.product_id = pr.id AND psi.status = "delivered") AS delivered_stock FROM products pr INNER JOIN categories cat ON pr.category_id = cat.id ORDER BY pr.created_at DESC')->fetchAll();
+$list = $pdo->query("SELECT pr.id, pr.name, cat.name AS category_name,
+    (SELECT COUNT(*) FROM product_stock_items psi WHERE psi.product_id = pr.id AND psi.status = 'available') AS available_stock,
+    (SELECT COUNT(*) FROM product_stock_items psi WHERE psi.product_id = pr.id AND psi.status = 'delivered') AS delivered_stock
+    FROM products pr
+    INNER JOIN categories cat ON pr.category_id = cat.id
+    ORDER BY pr.created_at DESC")->fetchAll();
 
 include __DIR__ . '/../templates/header.php';
 ?>

--- a/admin/products.php
+++ b/admin/products.php
@@ -5,14 +5,15 @@ use App\Auth;
 use App\AuditLog;
 use App\Database;
 use App\Helpers;
+use App\Services\ProductImageService;
 use App\Services\ProductStockService;
-use App\Settings;
 
 Auth::requireRoles(array('super_admin', 'admin', 'content'));
 
 $currentUser = $_SESSION['user'];
 $pdo = Database::connection();
 $errors = array();
+$warnings = array();
 $success = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = isset($_POST['action']) ? $_POST['action'] : '';
@@ -29,6 +30,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $description = isset($_POST['description']) ? trim($_POST['description']) : '';
             $status = isset($_POST['status']) ? 'active' : 'inactive';
             $automaticDelivery = isset($_POST['automatic_delivery']) ? 1 : 0;
+
+            $manualUpload = ProductImageService::validateManualUpload(isset($_FILES['product_image']) ? $_FILES['product_image'] : null);
+            $manualUploadData = null;
+            if ($manualUpload['status'] === 'error') {
+                $errors[] = isset($manualUpload['message']) ? $manualUpload['message'] : 'Görsel yüklenirken hata oluştu.';
+            } elseif ($manualUpload['status'] === 'ready' && isset($manualUpload['data'])) {
+                $manualUploadData = $manualUpload['data'];
+            }
 
             $costSanitized = preg_replace('/[^0-9.,-]/', '', $costInput);
             $costSanitized = str_replace(',', '.', (string)$costSanitized);
@@ -60,13 +69,48 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'automatic_delivery' => $automaticDelivery,
                 ));
 
+                $productId = (int)$pdo->lastInsertId();
+                $newImagePath = null;
+
+                if ($manualUploadData) {
+                    $storeResult = ProductImageService::storeManualUpload($manualUploadData);
+                    if ($storeResult['success']) {
+                        $newImagePath = $storeResult['path'];
+                    } elseif (isset($storeResult['message'])) {
+                        $warnings[] = $storeResult['message'];
+                    }
+                }
+
+                if (!$newImagePath) {
+                    $categoryStmt = $pdo->prepare('SELECT name FROM categories WHERE id = :id LIMIT 1');
+                    $categoryStmt->execute(array('id' => $categoryId));
+                    $categoryName = (string)$categoryStmt->fetchColumn();
+
+                    $aiResult = ProductImageService::maybeGenerateAiImage($productId, array(
+                        'name' => $name,
+                        'duration' => $automaticDelivery ? 'Anında teslimat' : 'Stoktan teslim',
+                        'category' => $categoryName,
+                    ));
+
+                    if ($aiResult['success']) {
+                        $newImagePath = $aiResult['path'];
+                    } elseif (isset($aiResult['message'])) {
+                        $warnings[] = $aiResult['message'];
+                    }
+                }
+
+                if ($newImagePath) {
+                    $imageStmt = $pdo->prepare('UPDATE products SET image = :image WHERE id = :id');
+                    $imageStmt->execute(array('image' => $newImagePath, 'id' => $productId));
+                }
+
                 $success = 'Ürün kaydedildi.';
 
                 AuditLog::record(
                     $currentUser['id'],
                     'product.create',
                     'product',
-                    (int)$pdo->lastInsertId(),
+                    $productId,
                     sprintf('Ürün eklendi: %s', $name)
                 );
             }
@@ -79,6 +123,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $description = isset($_POST['description']) ? trim($_POST['description']) : '';
             $status = isset($_POST['status']) ? 'active' : 'inactive';
             $automaticDelivery = isset($_POST['automatic_delivery']) ? 1 : 0;
+            $removeImage = isset($_POST['remove_product_image']);
+
+            $manualUploadCheck = ProductImageService::validateManualUpload(isset($_FILES['product_image']) ? $_FILES['product_image'] : null);
+            $manualUploadData = null;
+            if ($manualUploadCheck['status'] === 'error') {
+                $errors[] = isset($manualUploadCheck['message']) ? $manualUploadCheck['message'] : 'Görsel yüklenirken hata oluştu.';
+            } elseif ($manualUploadCheck['status'] === 'ready' && isset($manualUploadCheck['data'])) {
+                $manualUploadData = $manualUploadCheck['data'];
+            }
+
+            if ($manualUploadData) {
+                $removeImage = false;
+            }
+
             $costSanitized = preg_replace('/[^0-9.,-]/', '', $costInput);
             $costSanitized = str_replace(',', '.', (string)$costSanitized);
             $costPriceTry = $costSanitized !== '' ? (float)$costSanitized : 0.0;
@@ -95,6 +153,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
 
             if (!$errors) {
+                $existingStmt = $pdo->prepare('SELECT image FROM products WHERE id = :id LIMIT 1');
+                $existingStmt->execute(array('id' => $productId));
+                $existingImage = $existingStmt->fetchColumn();
+                if ($existingImage === false || $existingImage === '') {
+                    $existingImage = null;
+                } else {
+                    $existingImage = (string)$existingImage;
+                }
+
                 if ($automaticDelivery === 0) {
                     $availableStock = 0;
                     try {
@@ -123,6 +190,48 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'automatic_delivery' => $automaticDelivery,
                 ));
 
+                $newImagePath = null;
+                $imageShouldUpdate = false;
+
+                if ($manualUploadData) {
+                    $storeResult = ProductImageService::storeManualUpload($manualUploadData);
+                    if ($storeResult['success']) {
+                        $newImagePath = $storeResult['path'];
+                        $imageShouldUpdate = true;
+                    } elseif (isset($storeResult['message'])) {
+                        $warnings[] = $storeResult['message'];
+                    }
+                } elseif ($removeImage) {
+                    $imageShouldUpdate = true;
+                    $newImagePath = null;
+                } elseif (!$existingImage) {
+                    $categoryStmt = $pdo->prepare('SELECT name FROM categories WHERE id = :id LIMIT 1');
+                    $categoryStmt->execute(array('id' => $categoryId));
+                    $categoryName = (string)$categoryStmt->fetchColumn();
+
+                    $aiResult = ProductImageService::maybeGenerateAiImage($productId, array(
+                        'name' => $name,
+                        'duration' => $automaticDelivery ? 'Anında teslimat' : 'Stoktan teslim',
+                        'category' => $categoryName,
+                    ));
+
+                    if ($aiResult['success']) {
+                        $newImagePath = $aiResult['path'];
+                        $imageShouldUpdate = true;
+                    } elseif (isset($aiResult['message'])) {
+                        $warnings[] = $aiResult['message'];
+                    }
+                }
+
+                if ($imageShouldUpdate) {
+                    $imageStmt = $pdo->prepare('UPDATE products SET image = :image WHERE id = :id');
+                    $imageStmt->execute(array('image' => $newImagePath, 'id' => $productId));
+
+                    if ($existingImage && $existingImage !== $newImagePath) {
+                        ProductImageService::deleteImage($existingImage);
+                    }
+                }
+
                 $success = 'Ürün güncellendi.';
 
                 AuditLog::record(
@@ -136,6 +245,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } elseif ($action === 'delete_product') {
             $productId = isset($_POST['id']) ? (int)$_POST['id'] : 0;
             if ($productId > 0) {
+                $imageStmt = $pdo->prepare('SELECT image FROM products WHERE id = :id LIMIT 1');
+                $imageStmt->execute(array('id' => $productId));
+                $existingImage = $imageStmt->fetchColumn();
+                if ($existingImage === false || $existingImage === '') {
+                    $existingImage = null;
+                } else {
+                    $existingImage = (string)$existingImage;
+                }
+
                 $stmt = $pdo->prepare('DELETE FROM products WHERE id = :id');
                 $stmt->execute(array('id' => $productId));
 
@@ -148,6 +266,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $productId,
                     sprintf('Ürün silindi: #%d', $productId)
                 );
+
+                if ($existingImage) {
+                    ProductImageService::deleteImage($existingImage);
+                }
             }
         }
     }
@@ -215,7 +337,11 @@ $categoryPath = function ($categoryId) use (&$categoryMap) {
     return implode(' / ', array_reverse($parts));
 };
 
-$products = $pdo->query('SELECT pr.*, cat.name AS category_name, (SELECT COUNT(*) FROM product_stock_items psi WHERE psi.product_id = pr.id AND psi.status = "available") AS available_stock FROM products pr INNER JOIN categories cat ON pr.category_id = cat.id ORDER BY pr.created_at DESC')->fetchAll();
+$products = $pdo->query("SELECT pr.*, cat.name AS category_name,
+    (SELECT COUNT(*) FROM product_stock_items psi WHERE psi.product_id = pr.id AND psi.status = 'available') AS available_stock
+    FROM products pr
+    INNER JOIN categories cat ON pr.category_id = cat.id
+    ORDER BY pr.created_at DESC")->fetchAll();
 
 $pageTitle = 'Ürünler';
 
@@ -240,6 +366,16 @@ include __DIR__ . '/../templates/header.php';
                     </div>
                 <?php endif; ?>
 
+                <?php if ($warnings): ?>
+                    <div class="alert alert-warning">
+                        <ul class="mb-0">
+                            <?php foreach ($warnings as $warning): ?>
+                                <li><?= Helpers::sanitize($warning) ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                <?php endif; ?>
+
                 <?php if ($success): ?>
                     <div class="alert alert-success"><?= Helpers::sanitize($success) ?></div>
                 <?php endif; ?>
@@ -248,7 +384,7 @@ include __DIR__ . '/../templates/header.php';
                     <div class="alert alert-warning">Ürün ekleyebilmek için önce <a href="/admin/categories.php" class="alert-link">kategori oluşturmanız</a> gerekir.</div>
                 <?php endif; ?>
 
-                <form method="post" class="vstack gap-3">
+                <form method="post" class="vstack gap-3" enctype="multipart/form-data">
                     <input type="hidden" name="action" value="create_product">
                     <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
                     <div>
@@ -277,6 +413,11 @@ include __DIR__ . '/../templates/header.php';
                         <input class="form-check-input" type="checkbox" id="createAutomaticDelivery" name="automatic_delivery" value="1" checked>
                         <label class="form-check-label" for="createAutomaticDelivery">Otomatik teslimat</label>
                         <small class="text-muted d-block">Stok tanımlanana veya sağlayıcı bağlantısı kurulana kadar siparişler otomatik tamamlanır.</small>
+                    </div>
+                    <div>
+                        <label class="form-label">Ürün Görseli</label>
+                        <input type="file" name="product_image" class="form-control" accept="image/png,image/jpeg,image/webp">
+                        <small class="text-muted d-block mt-1">PNG, JPG veya WebP formatında en fazla 6 MB boyutunda görsel yükleyebilirsiniz.</small>
                     </div>
                     <div>
                         <label class="form-label">Açıklama</label>
@@ -373,7 +514,7 @@ include __DIR__ . '/../templates/header.php';
                                 <div class="modal fade" id="editProduct<?= (int)$product['id'] ?>" tabindex="-1" aria-hidden="true">
                                     <div class="modal-dialog modal-lg modal-dialog-centered">
                                         <div class="modal-content">
-                                            <form method="post">
+                                            <form method="post" enctype="multipart/form-data">
                                                 <div class="modal-header">
                                                     <h5 class="modal-title">Ürün Düzenle</h5>
                                                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -416,6 +557,22 @@ include __DIR__ . '/../templates/header.php';
                                                                 <input class="form-check-input" type="checkbox" id="productAuto<?= (int)$product['id'] ?>" name="automatic_delivery" value="1" <?= isset($product['automatic_delivery']) && (int)$product['automatic_delivery'] === 1 ? 'checked' : '' ?>>
                                                                 <label class="form-check-label" for="productAuto<?= (int)$product['id'] ?>">Otomatik teslimat</label>
                                                             </div>
+                                                        </div>
+                                                        <div class="col-12">
+                                                            <label class="form-label">Ürün Görseli</label>
+                                                            <?php $existingImagePath = isset($product['image']) ? trim((string)$product['image']) : ''; ?>
+                                                            <?php if ($existingImagePath !== ''): ?>
+                                                                <?php $imageUrl = $existingImagePath[0] === '/' ? $existingImagePath : '/' . ltrim($existingImagePath, '/'); ?>
+                                                                <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-3 mb-2">
+                                                                    <img src="<?= Helpers::sanitize($imageUrl) ?>" alt="<?= Helpers::sanitize($product['name']) ?>" class="rounded border" style="max-height: 72px;">
+                                                                    <div class="form-check mb-0">
+                                                                        <input class="form-check-input" type="checkbox" name="remove_product_image" value="1" id="removeProductImage<?= (int)$product['id'] ?>">
+                                                                        <label class="form-check-label" for="removeProductImage<?= (int)$product['id'] ?>">Mevcut görseli kaldır</label>
+                                                                    </div>
+                                                                </div>
+                                                            <?php endif; ?>
+                                                            <input type="file" name="product_image" class="form-control" accept="image/png,image/jpeg,image/webp">
+                                                            <small class="text-muted d-block mt-1">PNG, JPG veya WebP formatında en fazla 6 MB boyutunda yeni görsel yükleyebilirsiniz.</small>
                                                         </div>
                                                         <div class="col-12">
                                                             <label class="form-label">Açıklama</label>

--- a/admin/providers.php
+++ b/admin/providers.php
@@ -1,0 +1,316 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+use App\Auth;
+use App\Helpers;
+use App\Services\ProviderSyncService;
+
+Auth::requireRoles(array('super_admin', 'admin'));
+
+$provider = ProviderSyncService::getSource();
+$errors = array();
+$successMessages = array();
+$infoMessages = array();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = isset($_POST['action']) ? (string) $_POST['action'] : '';
+    $token = isset($_POST['csrf_token']) ? (string) $_POST['csrf_token'] : '';
+
+    if (!Helpers::verifyCsrf($token)) {
+        $errors[] = 'Oturum doğrulaması başarısız oldu. Lütfen sayfayı yenileyip tekrar deneyin.';
+    } else {
+        try {
+            if ($action === 'save_credentials') {
+                $result = ProviderSyncService::saveCredentials(array(
+                    'base_url' => $_POST['base_url'] ?? '',
+                    'consumer_key' => $_POST['consumer_key'] ?? '',
+                    'consumer_secret' => $_POST['consumer_secret'] ?? '',
+                    'status' => $_POST['status'] ?? 'inactive',
+                ));
+                if ($result['success']) {
+                    $successMessages[] = $result['message'];
+                } else {
+                    $errors[] = $result['message'];
+                }
+            } elseif ($action === 'test_connection') {
+                $result = ProviderSyncService::testConnection();
+                if ($result['success']) {
+                    $successMessages[] = $result['message'];
+                } else {
+                    $errors[] = $result['message'];
+                }
+            } elseif ($action === 'sync_categories') {
+                $result = ProviderSyncService::syncCategories();
+                if ($result['success']) {
+                    $counts = isset($result['counts']) ? $result['counts'] : array();
+                    $summary = sprintf('Kategoriler senkronize edildi. %d yeni, %d güncellendi.', $counts['created'] ?? 0, $counts['updated'] ?? 0);
+                    $successMessages[] = $summary;
+                } else {
+                    $errors[] = $result['message'];
+                }
+            } elseif ($action === 'sync_products') {
+                $result = ProviderSyncService::syncProducts();
+                if ($result['success']) {
+                    $counts = isset($result['counts']) ? $result['counts'] : array();
+                    $summary = sprintf('Ürünler senkronize edildi. %d yeni, %d güncellendi.', $counts['created'] ?? 0, $counts['updated'] ?? 0);
+                    $successMessages[] = $summary;
+                    if (!empty($result['new_products'])) {
+                        $infoMessages[] = sprintf('%d yeni ürün bulundu. Listeyi aşağıdan inceleyebilirsiniz.', count($result['new_products']));
+                    }
+                } else {
+                    $errors[] = $result['message'];
+                }
+            } elseif ($action === 'import_product') {
+                $remoteId = isset($_POST['remote_id']) ? (int) $_POST['remote_id'] : 0;
+                if ($remoteId <= 0) {
+                    $errors[] = 'İçeri aktarılacak ürün seçilemedi.';
+                } else {
+                    $result = ProviderSyncService::importProduct($remoteId, (int) $_SESSION['user']['id']);
+                    if ($result['success']) {
+                        $message = isset($result['message']) ? $result['message'] : 'Ürün içeri aktarıldı.';
+                        if (!empty($result['product_id'])) {
+                            $message .= ' <a href="/admin/products.php?highlight=' . (int) $result['product_id'] . '" class="text-decoration-none">Yeni ürünü düzenle</a>.';
+                        }
+                        $successMessages[] = $message;
+                    } else {
+                        $errors[] = $result['message'];
+                    }
+                }
+            }
+        } catch (RuntimeException $runtimeException) {
+            $errors[] = $runtimeException->getMessage();
+        } catch (Throwable $throwable) {
+            $errors[] = 'İşlem sırasında beklenmeyen bir hata oluştu: ' . $throwable->getMessage();
+        }
+    }
+
+    $provider = ProviderSyncService::getSource();
+}
+
+$remoteProducts = ProviderSyncService::listRemoteProducts();
+$remoteCategories = ProviderSyncService::listRemoteCategories();
+$highlightRemote = isset($_GET['highlight']) ? (int) $_GET['highlight'] : 0;
+
+$pageTitle = 'Sağlayıcılar';
+include __DIR__ . '/../templates/header.php';
+?>
+<div class="row g-4">
+    <div class="col-12 col-xl-4">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-header bg-white">
+                <h5 class="mb-0">WooCommerce Bağlantısı</h5>
+            </div>
+            <div class="card-body">
+                <?php if ($errors): ?>
+                    <div class="alert alert-danger">
+                        <ul class="mb-0">
+                            <?php foreach ($errors as $error): ?>
+                                <li><?= Helpers::sanitize($error) ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                <?php endif; ?>
+
+                <?php foreach ($successMessages as $message): ?>
+                    <div class="alert alert-success"><?= $message ?></div>
+                <?php endforeach; ?>
+
+                <?php foreach ($infoMessages as $message): ?>
+                    <div class="alert alert-info"><?= Helpers::sanitize($message) ?></div>
+                <?php endforeach; ?>
+
+                <form method="post" class="vstack gap-3">
+                    <input type="hidden" name="action" value="save_credentials">
+                    <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+
+                    <div>
+                        <label class="form-label">WordPress Site Adresi</label>
+                        <input type="url" name="base_url" class="form-control" placeholder="https://ornekmagaza.com" value="<?= Helpers::sanitize($provider['base_url'] ?? '') ?>" required>
+                        <small class="text-muted">WooCommerce kurulu sitenizin ana domain adresini girin.</small>
+                    </div>
+
+                    <div>
+                        <label class="form-label">Consumer Key</label>
+                        <input type="text" name="consumer_key" class="form-control" value="<?= Helpers::sanitize($provider['consumer_key'] ?? '') ?>" required>
+                    </div>
+
+                    <div>
+                        <label class="form-label">Consumer Secret</label>
+                        <input type="text" name="consumer_secret" class="form-control" value="<?= Helpers::sanitize($provider['consumer_secret'] ?? '') ?>" required>
+                    </div>
+
+                    <div>
+                        <label class="form-label">Durum</label>
+                        <select name="status" class="form-select">
+                            <option value="inactive" <?= isset($provider['status']) && $provider['status'] !== 'active' ? 'selected' : '' ?>>Pasif</option>
+                            <option value="active" <?= isset($provider['status']) && $provider['status'] === 'active' ? 'selected' : '' ?>>Aktif</option>
+                        </select>
+                    </div>
+
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Kaydet</button>
+                        <button type="submit" name="action" value="test_connection" class="btn btn-outline-secondary">Bağlantıyı Test Et</button>
+                    </div>
+                </form>
+
+                <hr>
+
+                <div class="vstack gap-2">
+                    <form method="post">
+                        <input type="hidden" name="action" value="sync_categories">
+                        <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                        <button type="submit" class="btn btn-outline-primary w-100">Kategorileri Senkronize Et</button>
+                    </form>
+                    <form method="post">
+                        <input type="hidden" name="action" value="sync_products">
+                        <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                        <button type="submit" class="btn btn-outline-success w-100">Ürünleri Senkronize Et</button>
+                    </form>
+                </div>
+
+                <hr>
+
+                <h6>Adım Adım Entegrasyon</h6>
+                <ol class="small ps-3">
+                    <li>WooCommerce panelinizde <strong>WooCommerce &gt; Ayarlar &gt; Gelişmiş &gt; REST API</strong> alanına gidin.</li>
+                    <li><em>Okuma / Yazma</em> izinli yeni bir anahtar oluşturun ve <strong>Consumer Key</strong> ile <strong>Secret</strong> değerlerini kopyalayın.</li>
+                    <li>Bu sayfada site adresi ve anahtarları kaydedin, ardından bağlantıyı test edin.</li>
+                    <li>Kategorileri ve ürünleri senkronize ettikten sonra yeni ürünler otomatik olarak duyuru şeklinde bildirilecektir.</li>
+                </ol>
+
+                <div class="alert alert-secondary small">
+                    <strong>Postman Koleksiyonu:</strong><br>
+                    Entegrasyonu manuel test etmek için <a href="/integrations/woocommerce/postman_collection.json" download>hazırlanan Postman koleksiyonunu</a> içeri aktarabilirsiniz.
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-12 col-xl-8">
+        <div class="card border-0 shadow-sm mb-4">
+            <div class="card-header bg-white d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">Sağlayıcı Ürünleri</h5>
+                <span class="text-muted small">Toplam <?= count($remoteProducts) ?> kayıt</span>
+            </div>
+            <div class="table-responsive">
+                <table class="table align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Ürün</th>
+                            <th>Kategori</th>
+                            <th>Fiyat</th>
+                            <th>Stok</th>
+                            <th>Durum</th>
+                            <th class="text-end">İşlem</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (!$remoteProducts): ?>
+                            <tr>
+                                <td colspan="7" class="text-center text-muted py-4">Henüz senkronize edilmiş ürün bulunmuyor.</td>
+                            </tr>
+                        <?php endif; ?>
+                        <?php foreach ($remoteProducts as $remote): ?>
+                            <?php
+                            $rowClasses = array();
+                            if ($highlightRemote && (int) $remote['remote_id'] === $highlightRemote) {
+                                $rowClasses[] = 'table-warning';
+                            }
+                            ?>
+                            <tr class="<?= implode(' ', $rowClasses) ?>">
+                                <td><?= (int) $remote['remote_id'] ?></td>
+                                <td>
+                                    <strong><?= Helpers::sanitize($remote['name'] ?? 'Ürün') ?></strong><br>
+                                    <small class="text-muted">WooCommerce: <?= Helpers::sanitize($remote['slug'] ?? '-') ?></small>
+                                </td>
+                                <td>
+                                    <?php if (!empty($remote['mapped_category_name'])): ?>
+                                        <span class="badge bg-secondary"><?= Helpers::sanitize($remote['mapped_category_name']) ?></span>
+                                    <?php elseif (!empty($remote['remote_category_name'])): ?>
+                                        <span class="text-muted"><?= Helpers::sanitize($remote['remote_category_name']) ?></span>
+                                    <?php else: ?>
+                                        <span class="text-muted">Kategori yok</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td>
+                                    <?php if (isset($remote['price']) && $remote['price'] !== null): ?>
+                                        <?= Helpers::sanitize(number_format((float) $remote['price'], 2, ',', '.')) ?> <?= Helpers::sanitize($remote['currency'] ?? 'TRY') ?>
+                                    <?php else: ?>
+                                        <span class="text-muted">Belirtilmemiş</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td>
+                                    <?php if ($remote['stock_quantity'] !== null): ?>
+                                        <span class="badge <?= (int) $remote['stock_quantity'] > 0 ? 'bg-success' : 'bg-danger' ?>"><?= (int) $remote['stock_quantity'] ?></span>
+                                    <?php else: ?>
+                                        <span class="badge bg-secondary">Bilinmiyor</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td>
+                                    <?php if (!empty($remote['imported_product_id'])): ?>
+                                        <span class="badge bg-success">İçe Aktarıldı</span>
+                                    <?php else: ?>
+                                        <span class="badge bg-warning text-dark">Beklemede</span>
+                                    <?php endif; ?>
+                                </td>
+                                <td class="text-end">
+                                    <?php if (empty($remote['imported_product_id'])): ?>
+                                        <form method="post" class="d-inline">
+                                            <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
+                                            <input type="hidden" name="action" value="import_product">
+                                            <input type="hidden" name="remote_id" value="<?= (int) $remote['remote_id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-primary">İçeri Aktar</button>
+                                        </form>
+                                    <?php else: ?>
+                                        <a href="/admin/products.php?highlight=<?= (int) $remote['imported_product_id'] ?>" class="btn btn-sm btn-outline-secondary">Ürünü Gör</a>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="card border-0 shadow-sm">
+            <div class="card-header bg-white">
+                <h5 class="mb-0">Kategori Eşleştirmeleri</h5>
+            </div>
+            <div class="table-responsive">
+                <table class="table align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Sağlayıcı Kategorisi</th>
+                            <th>Üst Kategori</th>
+                            <th>Eşleşen Yerel Kategori</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (!$remoteCategories): ?>
+                            <tr>
+                                <td colspan="4" class="text-center text-muted py-4">Henüz kategori senkronize edilmedi.</td>
+                            </tr>
+                        <?php endif; ?>
+                        <?php foreach ($remoteCategories as $category): ?>
+                            <tr>
+                                <td><?= (int) $category['remote_id'] ?></td>
+                                <td><?= Helpers::sanitize($category['name'] ?? '-') ?></td>
+                                <td><?= $category['parent_remote_id'] ? (int) $category['parent_remote_id'] : '-' ?></td>
+                                <td>
+                                    <?php if (!empty($category['mapped_category_name'])): ?>
+                                        <span class="badge bg-secondary"><?= Helpers::sanitize($category['mapped_category_name']) ?></span>
+                                    <?php else: ?>
+                                        <span class="text-muted">Eşleşme yok</span>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+<?php
+include __DIR__ . '/../templates/footer.php';

--- a/admin/settings-general.php
+++ b/admin/settings-general.php
@@ -5,12 +5,14 @@ use App\Auth;
 use App\AuditLog;
 use App\FeatureToggle;
 use App\Helpers;
+use App\Services\ProductImageService;
 use App\Settings;
 
 Auth::requireRoles(array('super_admin', 'admin'));
 
 $currentUser = $_SESSION['user'];
 $errors = array();
+$warnings = array();
 $success = '';
 
 $current = Settings::getMany(array(
@@ -18,12 +20,27 @@ $current = Settings::getMany(array(
     'site_tagline',
     'seo_meta_description',
     'seo_meta_keywords',
+    'site_logo',
     'pricing_commission_rate',
     'reseller_auto_suspend_enabled',
     'reseller_auto_suspend_threshold',
     'reseller_auto_suspend_days',
     'platform_default_locale',
+    'google_oauth_client_id',
+    'google_oauth_client_secret',
+    'ai_image_enabled',
+    'ai_api_key',
+    'ai_prompt',
+    'ai_image_template',
 ));
+
+$existingLogoSetting = isset($current['site_logo']) ? $current['site_logo'] : null;
+$currentLogoUrl = $existingLogoSetting ? '/' . ltrim((string) $existingLogoSetting, '/') : '';
+
+$existingAiTemplateSetting = isset($current['ai_image_template']) ? $current['ai_image_template'] : null;
+$currentAiTemplateUrl = $existingAiTemplateSetting ? '/' . ltrim((string) $existingAiTemplateSetting, '/') : '';
+
+$googleRedirectUri = Helpers::url('oauth/google.php', true);
 
 $featureLabels = array(
     'products' => 'Ürün kataloğu ve sipariş verme',
@@ -42,6 +59,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!Helpers::verifyCsrf($token)) {
         $errors[] = 'Oturum anahtarınız doğrulanamadı. Lütfen sayfayı yenileyin ve tekrar deneyin.';
     } else {
+        $runTestImage = isset($_POST['test_ai_image']);
         $siteName = isset($_POST['site_name']) ? trim($_POST['site_name']) : '';
         $siteTagline = isset($_POST['site_tagline']) ? trim($_POST['site_tagline']) : '';
         $metaDescription = isset($_POST['seo_meta_description']) ? trim($_POST['seo_meta_description']) : '';
@@ -76,12 +94,228 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
             }
 
+            $googleClientId = isset($_POST['google_oauth_client_id']) ? trim($_POST['google_oauth_client_id']) : '';
+            $googleClientSecret = isset($_POST['google_oauth_client_secret']) ? trim($_POST['google_oauth_client_secret']) : '';
+
+            if ($googleClientId !== '' && $googleClientSecret === '') {
+                $errors[] = 'Google Client Secret alanı boş bırakılamaz.';
+            }
+
+            if ($googleClientSecret !== '' && $googleClientId === '') {
+                $errors[] = 'Google Client ID alanı boş bırakılamaz.';
+            }
+
+            $newLogoSetting = $existingLogoSetting;
+
+            $aiEnabled = isset($_POST['ai_image_enabled']) ? '1' : '0';
+            $aiApiKey = isset($_POST['ai_api_key']) ? trim($_POST['ai_api_key']) : '';
+            $aiPrompt = isset($_POST['ai_prompt']) ? trim($_POST['ai_prompt']) : '';
+            $aiTemplateSetting = $existingAiTemplateSetting;
+            $aiTemplateFile = isset($_FILES['ai_image_template']) ? $_FILES['ai_image_template'] : null;
+            $removeAiTemplate = isset($_POST['remove_ai_image_template']);
+            $aiTemplateUploadInfo = null;
+
+            $logoFile = isset($_FILES['site_logo']) ? $_FILES['site_logo'] : null;
+            $removeLogo = isset($_POST['remove_site_logo']);
+            $logoUploadInfo = null;
+
+            if (is_array($logoFile) && isset($logoFile['error']) && (int)$logoFile['error'] !== UPLOAD_ERR_NO_FILE) {
+                if ((int)$logoFile['error'] !== UPLOAD_ERR_OK) {
+                    $errors[] = 'Site logosu yüklenirken bir hata oluştu. Lütfen dosyayı kontrol ederek tekrar deneyin.';
+                } elseif (!isset($logoFile['tmp_name']) || !is_uploaded_file((string) $logoFile['tmp_name'])) {
+                    $errors[] = 'Site logosu yüklemesi doğrulanamadı. Lütfen tekrar deneyin.';
+                } else {
+                    $tmpName = (string) $logoFile['tmp_name'];
+                    $detectedMime = '';
+
+                    if (class_exists('finfo')) {
+                        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+                        if ($finfo !== false) {
+                            $mimeType = $finfo->file($tmpName);
+                            if (is_string($mimeType) && $mimeType !== '') {
+                                $detectedMime = $mimeType;
+                            }
+                        }
+                    }
+
+                    if ($detectedMime === '' && function_exists('mime_content_type')) {
+                        $mimeCandidate = @mime_content_type($tmpName);
+                        if (is_string($mimeCandidate) && $mimeCandidate !== '') {
+                            $detectedMime = $mimeCandidate;
+                        }
+                    }
+
+                    if ($detectedMime === '' && function_exists('getimagesize')) {
+                        $imageSize = @getimagesize($tmpName);
+                        if ($imageSize && isset($imageSize['mime']) && is_string($imageSize['mime'])) {
+                            $detectedMime = $imageSize['mime'];
+                        }
+                    }
+
+                    $allowedMimes = array(
+                        'image/png' => 'png',
+                        'image/jpeg' => 'jpg',
+                        'image/jpg' => 'jpg',
+                        'image/pjpeg' => 'jpg',
+                        'image/svg+xml' => 'svg',
+                        'image/webp' => 'webp',
+                    );
+
+                    $extension = '';
+                    if ($detectedMime !== '' && isset($allowedMimes[$detectedMime])) {
+                        $extension = $allowedMimes[$detectedMime];
+                    } else {
+                        $originalExtension = '';
+                        if (isset($logoFile['name'])) {
+                            $originalExtension = strtolower((string) pathinfo((string) $logoFile['name'], PATHINFO_EXTENSION));
+                        }
+                        if ($originalExtension === 'jpeg') {
+                            $originalExtension = 'jpg';
+                        }
+                        if (in_array($originalExtension, array('png', 'jpg', 'svg', 'webp'), true)) {
+                            $extension = $originalExtension;
+                        }
+                    }
+
+                    if ($extension === '') {
+                        $errors[] = 'Site logosu olarak yalnızca PNG, JPG, SVG veya WebP dosyaları yükleyebilirsiniz.';
+                    }
+
+                    $fileSize = isset($logoFile['size']) ? (int) $logoFile['size'] : 0;
+                    if ($extension !== '' && $fileSize > 0) {
+                        $maxSize = 4 * 1024 * 1024;
+                        if ($fileSize > $maxSize) {
+                            $errors[] = 'Site logosu 4 MB boyutundan büyük olamaz.';
+                        }
+                    }
+
+                    if (!$errors) {
+                        $originalName = isset($logoFile['name']) ? (string) $logoFile['name'] : 'logo.' . $extension;
+                        $baseName = strtolower((string) pathinfo($originalName, PATHINFO_FILENAME));
+                        $safeBase = preg_replace('/[^a-z0-9_-]+/i', '-', $baseName);
+                        if ($safeBase === null || $safeBase === '') {
+                            $safeBase = 'logo';
+                        }
+
+                        $logoUploadInfo = array(
+                            'tmp_name' => $tmpName,
+                            'extension' => $extension,
+                            'base' => $safeBase,
+                        );
+                    }
+                }
+            }
+
+            if (is_array($aiTemplateFile) && isset($aiTemplateFile['error']) && (int)$aiTemplateFile['error'] !== UPLOAD_ERR_NO_FILE) {
+                if ((int)$aiTemplateFile['error'] !== UPLOAD_ERR_OK) {
+                    $errors[] = 'Görsel şablonu yüklenirken bir hata oluştu. Lütfen tekrar deneyin.';
+                } elseif (!isset($aiTemplateFile['tmp_name']) || !is_uploaded_file((string)$aiTemplateFile['tmp_name'])) {
+                    $errors[] = 'Görsel şablonu yüklemesi doğrulanamadı.';
+                } else {
+                    $templateTmpName = (string)$aiTemplateFile['tmp_name'];
+                    $imageInfo = @getimagesize($templateTmpName);
+                    if (!$imageInfo || !isset($imageInfo['mime']) || $imageInfo['mime'] !== 'image/png') {
+                        $errors[] = 'Şablon olarak yalnızca PNG dosyaları yükleyebilirsiniz.';
+                    }
+
+                    $templateSize = isset($aiTemplateFile['size']) ? (int)$aiTemplateFile['size'] : 0;
+                    if ($templateSize > 0) {
+                        $maxTemplateSize = 6 * 1024 * 1024;
+                        if ($templateSize > $maxTemplateSize) {
+                            $errors[] = 'Görsel şablon dosyası 6 MB boyutunu aşamaz.';
+                        }
+                    }
+
+                    if (!$errors) {
+                        $originalName = isset($aiTemplateFile['name']) ? (string)$aiTemplateFile['name'] : 'ai-template.png';
+                        $baseName = strtolower((string) pathinfo($originalName, PATHINFO_FILENAME));
+                        $safeBase = preg_replace('/[^a-z0-9_-]+/i', '-', $baseName);
+                        if ($safeBase === null || $safeBase === '') {
+                            $safeBase = 'ai-template';
+                        }
+
+                        $aiTemplateUploadInfo = array(
+                            'tmp_name' => $templateTmpName,
+                            'base' => $safeBase,
+                        );
+                    }
+                }
+            }
+
+            if (!$errors) {
+                if ($logoUploadInfo) {
+                    $rootPath = dirname(__DIR__);
+                    $uploadDir = $rootPath . '/uploads';
+                    if (!is_dir($uploadDir) && !mkdir($uploadDir, 0775, true) && !is_dir($uploadDir)) {
+                        $errors[] = 'Site logosu için yükleme klasörü oluşturulamadı.';
+                    } else {
+                        try {
+                            $randomSuffix = bin2hex(random_bytes(4));
+                        } catch (\Throwable $exception) {
+                            $randomSuffix = substr(md5(uniqid('', true)), 0, 8);
+                        }
+                        $fileName = $logoUploadInfo['base'] . '-' . date('YmdHis') . '-' . $randomSuffix . '.' . $logoUploadInfo['extension'];
+                        $targetPath = rtrim($uploadDir, '/\\') . '/' . $fileName;
+
+                        if (!move_uploaded_file($logoUploadInfo['tmp_name'], $targetPath)) {
+                            $errors[] = 'Site logosu yüklenirken beklenmedik bir hata oluştu.';
+                        } else {
+                            $newLogoSetting = '/uploads/' . $fileName;
+                        }
+                    }
+                } elseif ($removeLogo) {
+                    $newLogoSetting = null;
+                }
+            }
+
+            if (!$errors) {
+                if ($aiTemplateUploadInfo) {
+                    $rootPath = dirname(__DIR__);
+                    $templateDir = $rootPath . '/uploads/ai-template';
+                    if (!is_dir($templateDir) && !mkdir($templateDir, 0775, true) && !is_dir($templateDir)) {
+                        $errors[] = 'Görsel şablonu için yükleme klasörü oluşturulamadı.';
+                    } else {
+                        try {
+                            $randomSuffix = bin2hex(random_bytes(4));
+                        } catch (\Throwable $exception) {
+                            $randomSuffix = substr(md5(uniqid('', true)), 0, 8);
+                        }
+                        $fileName = $aiTemplateUploadInfo['base'] . '-' . date('YmdHis') . '-' . $randomSuffix . '.png';
+                        $targetPath = rtrim($templateDir, '/\\') . '/' . $fileName;
+
+                        if (!move_uploaded_file($aiTemplateUploadInfo['tmp_name'], $targetPath)) {
+                            $errors[] = 'Görsel şablon kaydedilirken hata oluştu.';
+                        } else {
+                            $aiTemplateSetting = '/uploads/ai-template/' . $fileName;
+                        }
+                    }
+                } elseif ($removeAiTemplate && $existingAiTemplateSetting) {
+                    $aiTemplateSetting = null;
+                }
+            }
+
             if (!$errors) {
                 Settings::set('site_name', $siteName);
                 Settings::set('site_tagline', $siteTagline !== '' ? $siteTagline : null);
                 Settings::set('seo_meta_description', $metaDescription !== '' ? $metaDescription : null);
                 Settings::set('seo_meta_keywords', $metaKeywords !== '' ? $metaKeywords : null);
                 Settings::set('pricing_commission_rate', (string)$commissionRate);
+
+                if ($newLogoSetting !== $existingLogoSetting) {
+                    Settings::set('site_logo', $newLogoSetting !== null ? $newLogoSetting : null);
+
+                    if ($existingLogoSetting && $existingLogoSetting !== $newLogoSetting) {
+                        $rootPath = dirname(__DIR__);
+                        $previousPath = $rootPath . '/' . ltrim((string) $existingLogoSetting, '/\\');
+                        $uploadsBase = rtrim($rootPath . '/uploads', '/\\') . DIRECTORY_SEPARATOR;
+                        $realPrevious = @realpath($previousPath);
+                        if ($realPrevious && strpos($realPrevious, $uploadsBase) === 0 && is_file($realPrevious)) {
+                            @unlink($realPrevious);
+                        }
+                    }
+
+                    $existingLogoSetting = $newLogoSetting;
+                }
 
                 Settings::set('platform_default_locale', $defaultLocale);
                 foreach ($featureLabels as $key => $label) {
@@ -99,6 +333,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     Settings::set('reseller_auto_suspend_days', null);
                 }
 
+                Settings::set('google_oauth_client_id', $googleClientId !== '' ? $googleClientId : null);
+                Settings::set('google_oauth_client_secret', $googleClientSecret !== '' ? $googleClientSecret : null);
+
+                Settings::set('ai_image_enabled', $aiEnabled);
+                Settings::set('ai_api_key', $aiApiKey !== '' ? $aiApiKey : null);
+                Settings::set('ai_prompt', $aiPrompt !== '' ? $aiPrompt : null);
+                if ($aiTemplateSetting !== $existingAiTemplateSetting) {
+                    Settings::set('ai_image_template', $aiTemplateSetting !== null ? $aiTemplateSetting : null);
+
+                    if ($existingAiTemplateSetting && $existingAiTemplateSetting !== $aiTemplateSetting) {
+                        $rootPath = dirname(__DIR__);
+                        $previousTemplate = $rootPath . '/' . ltrim((string)$existingAiTemplateSetting, '/\\');
+                        $templateBase = rtrim($rootPath . '/uploads/ai-template', '/\\') . DIRECTORY_SEPARATOR;
+                        $realPrev = @realpath($previousTemplate);
+                        if ($realPrev && strpos($realPrev, $templateBase) === 0 && is_file($realPrev)) {
+                            @unlink($realPrev);
+                        }
+                    }
+
+                    $existingAiTemplateSetting = $aiTemplateSetting;
+                }
+
                 $success = 'Genel ayarlar kaydedildi.';
                 AuditLog::record(
                     $currentUser['id'],
@@ -113,12 +369,38 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'site_tagline',
                     'seo_meta_description',
                     'seo_meta_keywords',
+                    'site_logo',
                     'pricing_commission_rate',
                     'reseller_auto_suspend_enabled',
                     'reseller_auto_suspend_threshold',
                     'reseller_auto_suspend_days',
                     'platform_default_locale',
+                    'google_oauth_client_id',
+                    'google_oauth_client_secret',
+                    'ai_image_enabled',
+                    'ai_api_key',
+                    'ai_prompt',
+                    'ai_image_template',
                 ));
+                $existingLogoSetting = isset($current['site_logo']) ? $current['site_logo'] : null;
+                $currentLogoUrl = $existingLogoSetting ? '/' . ltrim((string) $existingLogoSetting, '/') : '';
+                $existingAiTemplateSetting = isset($current['ai_image_template']) ? $current['ai_image_template'] : null;
+                $currentAiTemplateUrl = $existingAiTemplateSetting ? '/' . ltrim((string) $existingAiTemplateSetting, '/') : '';
+
+                if ($runTestImage) {
+                    if (isset($current['ai_image_enabled']) && $current['ai_image_enabled'] === '1') {
+                        $testResult = ProductImageService::runTestGeneration();
+                        if (!empty($testResult['success'])) {
+                            $success .= ' Yapay zekâ test görseli başarıyla üretildi.';
+                        } elseif (isset($testResult['message'])) {
+                            $warnings[] = 'Test görseli üretilemedi: ' . $testResult['message'];
+                        } else {
+                            $warnings[] = 'Test görseli üretilemedi. Lütfen ayarları kontrol edin.';
+                        }
+                    } else {
+                        $warnings[] = 'Test görseli oluşturmak için yapay zekâ görsel oluşturmayı etkinleştirin.';
+                    }
+                }
             }
     }
 }
@@ -144,11 +426,21 @@ include __DIR__ . '/../templates/header.php';
                     </div>
                 <?php endif; ?>
 
+                <?php if ($warnings): ?>
+                    <div class="alert alert-warning">
+                        <ul class="mb-0">
+                            <?php foreach ($warnings as $warning): ?>
+                                <li><?= Helpers::sanitize($warning) ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                <?php endif; ?>
+
                 <?php if ($success): ?>
                     <div class="alert alert-success"><?= Helpers::sanitize($success) ?></div>
                 <?php endif; ?>
 
-                <form method="post" class="vstack gap-4">
+                <form method="post" enctype="multipart/form-data" class="vstack gap-4">
                     <input type="hidden" name="action" value="save_general">
                     <input type="hidden" name="csrf_token" value="<?= Helpers::sanitize(Helpers::csrfToken()) ?>">
 
@@ -168,6 +460,24 @@ include __DIR__ . '/../templates/header.php';
                         <div class="col-12">
                             <label class="form-label">SEO Anahtar Kelimeler</label>
                             <input type="text" name="seo_meta_keywords" class="form-control" value="<?= Helpers::sanitize(isset($current['seo_meta_keywords']) ? $current['seo_meta_keywords'] : '') ?>" placeholder="Virgülle ayırın">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">Site Logosu</label>
+                            <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-3">
+                                <?php if ($currentLogoUrl): ?>
+                                    <div class="d-flex align-items-center gap-3">
+                                        <img src="<?= Helpers::sanitize($currentLogoUrl) ?>" alt="<?= Helpers::sanitize('Site Logosu') ?>" class="border rounded bg-white p-2" style="max-height: 60px;">
+                                        <div class="form-check mb-0">
+                                            <input class="form-check-input" type="checkbox" value="1" name="remove_site_logo" id="removeSiteLogo">
+                                            <label class="form-check-label small text-muted" for="removeSiteLogo"><?= Helpers::sanitize('Mevcut logoyu kaldır') ?></label>
+                                        </div>
+                                    </div>
+                                <?php endif; ?>
+                                <div class="flex-grow-1">
+                                    <input type="file" name="site_logo" class="form-control" accept=".png,.jpg,.jpeg,.svg,.webp">
+                                    <small class="text-muted d-block mt-2"><?= Helpers::sanitize('PNG, JPG, SVG veya WebP formatında en fazla 4 MB boyutunda logo yükleyebilirsiniz.') ?></small>
+                                </div>
+                            </div>
                         </div>
                     </div>
 
@@ -189,6 +499,61 @@ include __DIR__ . '/../templates/header.php';
                                 <?php endforeach; ?>
                             </select>
                             <small class="text-muted">Bayi profili aksi seçmedikçe bu dil kullanılır.</small>
+                        </div>
+                    </div>
+
+                    <hr>
+
+                    <div>
+                        <h6>Google ile Giriş</h6>
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label class="form-label">Client ID</label>
+                                <input type="text" name="google_oauth_client_id" class="form-control" value="<?= Helpers::sanitize(isset($current['google_oauth_client_id']) ? $current['google_oauth_client_id'] : '') ?>" placeholder="xxxx.apps.googleusercontent.com">
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label">Client Secret</label>
+                                <input type="text" name="google_oauth_client_secret" class="form-control" value="<?= Helpers::sanitize(isset($current['google_oauth_client_secret']) ? $current['google_oauth_client_secret'] : '') ?>" placeholder="Google secret değeri">
+                            </div>
+                            <div class="col-12">
+                                <small class="text-muted">Google Cloud Console &gt; Credentials üzerinden OAuth 2.0 kimlik bilgileri oluşturun. Yetkili yönlendirme URI'si: <code><?= Helpers::sanitize($googleRedirectUri) ?></code></small>
+                            </div>
+                        </div>
+                    </div>
+
+                    <hr>
+
+                    <div>
+                        <h6>Görsel Oluşturucu</h6>
+                        <div class="form-check form-switch mb-3">
+                            <input type="hidden" name="ai_image_enabled" value="0">
+                            <input class="form-check-input" type="checkbox" id="aiImageEnabled" name="ai_image_enabled" value="1" <?= isset($current['ai_image_enabled']) && $current['ai_image_enabled'] === '1' ? 'checked' : '' ?>>
+                            <label class="form-check-label" for="aiImageEnabled">Yapay zekâ görsel oluşturmayı etkinleştir</label>
+                        </div>
+                        <div class="row g-3 align-items-end">
+                            <div class="col-md-6">
+                                <label class="form-label">OpenAI API Key</label>
+                                <input type="text" name="ai_api_key" class="form-control" value="<?= Helpers::sanitize(isset($current['ai_api_key']) ? $current['ai_api_key'] : '') ?>" placeholder="sk-...">
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label">Varsayılan Prompt</label>
+                                <textarea name="ai_prompt" class="form-control" rows="3" placeholder="Örn: Modern, yüksek çözünürlüklü ürün görseli"><?= Helpers::sanitize(isset($current['ai_prompt']) ? $current['ai_prompt'] : '') ?></textarea>
+                                <small class="text-muted">Ürün adı, süre ve kategori bu prompta otomatik eklenir.</small>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label">Görsel Şablonu (PNG)</label>
+                                <?php if ($currentAiTemplateUrl): ?>
+                                    <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-3 mb-2">
+                                        <img src="<?= Helpers::sanitize($currentAiTemplateUrl) ?>" alt="Görsel şablonu" class="rounded border bg-white" style="max-height: 80px;">
+                                        <div class="form-check mb-0">
+                                            <input class="form-check-input" type="checkbox" name="remove_ai_image_template" value="1" id="removeAiTemplate">
+                                            <label class="form-check-label" for="removeAiTemplate">Mevcut şablonu kaldır</label>
+                                        </div>
+                                    </div>
+                                <?php endif; ?>
+                                <input type="file" name="ai_image_template" class="form-control" accept="image/png">
+                                <small class="text-muted d-block mt-1">Saydam arka planlı PNG yükleyin. Yapay zekâ bu şablonu düzenleyerek ürün görseli üretir.</small>
+                            </div>
                         </div>
                     </div>
 
@@ -230,8 +595,9 @@ include __DIR__ . '/../templates/header.php';
                         </div>
                     </div>
 
-                <div class="d-flex justify-content-end">
+                <div class="d-flex flex-column flex-sm-row justify-content-end gap-2">
                     <button type="submit" class="btn btn-primary">Ayarları Kaydet</button>
+                    <button type="submit" name="test_ai_image" value="1" class="btn btn-outline-secondary">Test Görseli Üret</button>
                 </div>
             </form>
         </div>

--- a/api/index.php
+++ b/api/index.php
@@ -50,12 +50,12 @@ switch (true) {
         try {
             $pdo = Database::connection();
             $stmt = $pdo->query(
-                'SELECT p.id, p.name, p.description, p.price, p.automatic_delivery, c.name AS category_name,
-                        (SELECT COUNT(*) FROM product_stock_items WHERE product_id = p.id AND status = "available") AS stock
+                "SELECT p.id, p.name, p.description, p.price, p.automatic_delivery, c.name AS category_name,
+                        (SELECT COUNT(*) FROM product_stock_items WHERE product_id = p.id AND status = 'available') AS stock
                  FROM products p
                  INNER JOIN categories c ON c.id = p.category_id
-                 WHERE p.status = "active"
-                 ORDER BY p.name ASC'
+                 WHERE p.status = 'active'
+                 ORDER BY p.name ASC"
             );
             $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
         } catch (\PDOException $exception) {

--- a/app/Auth.php
+++ b/app/Auth.php
@@ -144,6 +144,20 @@ class Auth
         return null;
     }
 
+    public static function findActiveUserByEmail(string $email): ?array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT * FROM users WHERE email = :email AND status = :status LIMIT 1');
+        $stmt->execute([
+            'email' => $email,
+            'status' => 'active',
+        ]);
+
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $user ?: null;
+    }
+
     /**
      * @param string $name
      * @param string $email

--- a/app/Services/AnnouncementService.php
+++ b/app/Services/AnnouncementService.php
@@ -88,4 +88,35 @@ final class AnnouncementService
             return array();
         }
     }
+
+    public static function create(string $title, string $body, string $audience = 'admin', bool $pinned = false, ?int $createdBy = null): ?int
+    {
+        try {
+            $pdo = Database::connection();
+        } catch (PDOException $exception) {
+            return null;
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO announcements (title, body, audience, is_active, pinned, created_by, created_at) VALUES (:title, :body, :audience, 1, :pinned, :created_by, NOW())');
+        $stmt->execute(array(
+            'title' => $title,
+            'body' => $body,
+            'audience' => in_array($audience, array('admin', 'reseller', 'all'), true) ? $audience : 'admin',
+            'pinned' => $pinned ? 1 : 0,
+            'created_by' => $createdBy,
+        ));
+
+        return (int) $pdo->lastInsertId();
+    }
+
+    public static function deactivate(int $announcementId): void
+    {
+        try {
+            $pdo = Database::connection();
+        } catch (PDOException $exception) {
+            return;
+        }
+
+        $pdo->prepare('UPDATE announcements SET is_active = 0, updated_at = NOW() WHERE id = :id')->execute(array('id' => $announcementId));
+    }
 }

--- a/app/Services/ProductImageService.php
+++ b/app/Services/ProductImageService.php
@@ -1,0 +1,414 @@
+<?php
+
+namespace App\Services;
+
+use App\Settings;
+
+class ProductImageService
+{
+    private const PRODUCT_DIRECTORY = '/uploads/products';
+    private const TEMPLATE_DIRECTORY = '/uploads/ai-template';
+    private const LOG_FILE = '/logs/ai-image.log';
+
+    /**
+     * @param array|null $file
+     * @return array{status:string,message?:string,data?:array}
+     */
+    public static function validateManualUpload($file): array
+    {
+        if (!is_array($file) || !isset($file['error'])) {
+            return array('status' => 'empty');
+        }
+
+        $errorCode = (int) $file['error'];
+        if ($errorCode === UPLOAD_ERR_NO_FILE) {
+            return array('status' => 'empty');
+        }
+
+        if ($errorCode !== UPLOAD_ERR_OK) {
+            return array('status' => 'error', 'message' => 'Görsel yüklenirken bir hata oluştu (kod ' . $errorCode . ').');
+        }
+
+        if (!isset($file['tmp_name']) || !is_uploaded_file((string) $file['tmp_name'])) {
+            return array('status' => 'error', 'message' => 'Yüklenen dosya doğrulanamadı.');
+        }
+
+        $tmpName = (string) $file['tmp_name'];
+        $fileSize = isset($file['size']) ? (int) $file['size'] : 0;
+        if ($fileSize <= 0) {
+            return array('status' => 'error', 'message' => 'Görsel dosyası boş görünüyor.');
+        }
+
+        $maxSize = 6 * 1024 * 1024; // 6 MB
+        if ($fileSize > $maxSize) {
+            return array('status' => 'error', 'message' => 'Görsel dosyası 6 MB boyutunu aşamaz.');
+        }
+
+        $detectedMime = self::detectMimeType($file, $tmpName);
+        $allowedMimes = array(
+            'image/png' => 'png',
+            'image/jpeg' => 'jpg',
+            'image/jpg' => 'jpg',
+            'image/pjpeg' => 'jpg',
+            'image/webp' => 'webp',
+        );
+
+        $extension = '';
+        if ($detectedMime !== '' && isset($allowedMimes[$detectedMime])) {
+            $extension = $allowedMimes[$detectedMime];
+        } else {
+            $originalExtension = isset($file['name']) ? strtolower((string) pathinfo((string) $file['name'], PATHINFO_EXTENSION)) : '';
+            if ($originalExtension === 'jpeg') {
+                $originalExtension = 'jpg';
+            }
+            if (in_array($originalExtension, array('png', 'jpg', 'webp'), true)) {
+                $extension = $originalExtension;
+            }
+        }
+
+        if ($extension === '') {
+            return array('status' => 'error', 'message' => 'Yalnızca PNG, JPG veya WebP formatındaki görseller yüklenebilir.');
+        }
+
+        return array(
+            'status' => 'ready',
+            'data' => array(
+                'tmp_name' => $tmpName,
+                'extension' => $extension,
+                'original_name' => isset($file['name']) ? (string) $file['name'] : ('product.' . $extension),
+            ),
+        );
+    }
+
+    /**
+     * @param array $uploadData
+     * @return array{success:bool,message?:string,path?:string}
+     */
+    public static function storeManualUpload(array $uploadData): array
+    {
+        if (!isset($uploadData['tmp_name'], $uploadData['extension'], $uploadData['original_name'])) {
+            return array('success' => false, 'message' => 'Görsel yükleme bilgileri eksik.');
+        }
+
+        $targetDirectory = self::absolutePath(self::PRODUCT_DIRECTORY);
+        if (!self::ensureDirectory($targetDirectory)) {
+            return array('success' => false, 'message' => 'Görsel klasörü oluşturulamadı.');
+        }
+
+        $safeBase = strtolower((string) pathinfo((string) $uploadData['original_name'], PATHINFO_FILENAME));
+        $safeBase = preg_replace('/[^a-z0-9_-]+/i', '-', $safeBase);
+        if ($safeBase === null || $safeBase === '') {
+            $safeBase = 'product-image';
+        }
+
+        try {
+            $randomSuffix = bin2hex(random_bytes(6));
+        } catch (\Throwable $exception) {
+            $randomSuffix = substr(md5(uniqid('', true)), 0, 12);
+        }
+
+        $fileName = $safeBase . '-' . date('YmdHis') . '-' . $randomSuffix . '.' . $uploadData['extension'];
+        $destination = rtrim($targetDirectory, '/\\') . '/' . $fileName;
+
+        if (!move_uploaded_file((string) $uploadData['tmp_name'], $destination)) {
+            return array('success' => false, 'message' => 'Görsel kaydedilirken hata oluştu.');
+        }
+
+        return array(
+            'success' => true,
+            'path' => self::relativeWebPath(self::PRODUCT_DIRECTORY . '/' . $fileName),
+        );
+    }
+
+    /**
+     * @param int $productId
+     * @param array<string,mixed> $productData
+     * @return array{success:bool,message?:string,path?:string}
+     */
+    public static function maybeGenerateAiImage(int $productId, array $productData): array
+    {
+        $enabled = Settings::get('ai_image_enabled');
+        if (!$enabled || (string) $enabled !== '1') {
+            return array('success' => false, 'message' => 'Yapay zekâ görsel oluşturma devre dışı.');
+        }
+
+        $apiKey = (string) Settings::get('ai_api_key');
+        $promptBase = (string) Settings::get('ai_prompt');
+        $templateSetting = (string) Settings::get('ai_image_template');
+
+        if ($apiKey === '') {
+            self::log('Ürün #' . $productId . ' için API anahtarı tanımlı değil.');
+            return array('success' => false, 'message' => 'API anahtarı bulunamadı.');
+        }
+
+        if ($templateSetting === '') {
+            self::log('Ürün #' . $productId . ' için görsel şablonu ayarlanmamış.');
+            return array('success' => false, 'message' => 'Şablon görsel yüklenmemiş.');
+        }
+
+        $templatePath = self::absolutePath($templateSetting);
+        if (!is_file($templatePath)) {
+            self::log('Ürün #' . $productId . ' için şablon dosyası bulunamadı: ' . $templatePath);
+            return array('success' => false, 'message' => 'Şablon dosyası bulunamadı.');
+        }
+
+        $promptParts = array();
+        if ($promptBase !== '') {
+            $promptParts[] = $promptBase;
+        }
+
+        $name = isset($productData['name']) ? (string) $productData['name'] : '';
+        $duration = isset($productData['duration']) ? (string) $productData['duration'] : '';
+        $category = isset($productData['category']) ? (string) $productData['category'] : '';
+
+        if ($name !== '') {
+            $promptParts[] = 'Ürün adı: ' . $name;
+        }
+        if ($duration !== '') {
+            $promptParts[] = 'Süre: ' . $duration;
+        }
+        if ($category !== '') {
+            $promptParts[] = 'Kategori: ' . $category;
+        }
+
+        $prompt = trim(implode(' \n', $promptParts));
+        if ($prompt === '') {
+            $prompt = 'Profesyonel yazılım ürün görseli oluştur';
+        }
+
+        $ch = curl_init('https://api.openai.com/v1/images/edits');
+        if (!$ch) {
+            self::log('Ürün #' . $productId . ' için cURL başlatılamadı.');
+            return array('success' => false, 'message' => 'cURL başlatılamadı.');
+        }
+
+        if (function_exists('curl_file_create')) {
+            $cfile = curl_file_create($templatePath, 'image/png', basename($templatePath));
+        } else {
+            $cfile = new \CURLFile($templatePath, 'image/png', basename($templatePath));
+        }
+        $postFields = array(
+            'model' => 'gpt-image-1',
+            'prompt' => $prompt,
+            'image' => $cfile,
+        );
+
+        curl_setopt_array($ch, array(
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 60,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $postFields,
+            CURLOPT_HTTPHEADER => array(
+                'Authorization: Bearer ' . $apiKey,
+            ),
+        ));
+
+        $response = curl_exec($ch);
+        $curlError = curl_error($ch);
+        $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($response === false) {
+            self::log('Ürün #' . $productId . ' için cURL hatası: ' . $curlError);
+            return array('success' => false, 'message' => 'API isteği başarısız: ' . ($curlError !== '' ? $curlError : 'Bilinmeyen hata'));
+        }
+
+        $decoded = json_decode((string) $response, true);
+        if (!is_array($decoded)) {
+            self::log('Ürün #' . $productId . ' için API yanıtı çözümlenemedi: ' . $response);
+            return array('success' => false, 'message' => 'API yanıtı çözümlenemedi.');
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            $message = isset($decoded['error']['message']) ? (string) $decoded['error']['message'] : 'Bilinmeyen API hatası.';
+            self::log(sprintf('Ürün #%d için API hata yanıtı (%d): %s', $productId, $statusCode, $message));
+            return array('success' => false, 'message' => 'API hatası: ' . $message);
+        }
+
+        if (empty($decoded['data'][0]['b64_json'])) {
+            self::log('Ürün #' . $productId . ' için API verisi eksik: ' . json_encode($decoded));
+            return array('success' => false, 'message' => 'API yanıtında görsel verisi bulunamadı.');
+        }
+
+        $imageData = base64_decode((string) $decoded['data'][0]['b64_json']);
+        if ($imageData === false) {
+            self::log('Ürün #' . $productId . ' için base64 çözme başarısız.');
+            return array('success' => false, 'message' => 'Görsel verisi işlenemedi.');
+        }
+
+        $targetDirectory = self::absolutePath(self::PRODUCT_DIRECTORY);
+        if (!self::ensureDirectory($targetDirectory)) {
+            return array('success' => false, 'message' => 'Görsel klasörü oluşturulamadı.');
+        }
+
+        try {
+            $randomSuffix = bin2hex(random_bytes(8));
+        } catch (\Throwable $exception) {
+            $randomSuffix = substr(md5(uniqid('', true)), 0, 16);
+        }
+
+        $fileName = 'ai-product-' . $productId . '-' . date('YmdHis') . '-' . $randomSuffix . '.png';
+        $destination = rtrim($targetDirectory, '/\\') . '/' . $fileName;
+
+        if (file_put_contents($destination, $imageData) === false) {
+            self::log('Ürün #' . $productId . ' için görsel kaydedilemedi: ' . $destination);
+            return array('success' => false, 'message' => 'Görsel kaydedilemedi.');
+        }
+
+        self::log('Ürün #' . $productId . ' için yapay zekâ görseli üretildi.', array('prompt' => $prompt));
+
+        return array(
+            'success' => true,
+            'path' => self::relativeWebPath(self::PRODUCT_DIRECTORY . '/' . $fileName),
+        );
+    }
+
+    /**
+     * @param string|null $path
+     * @return void
+     */
+    public static function deleteImage($path): void
+    {
+        if (!$path) {
+            return;
+        }
+
+        $absolute = self::absolutePath($path);
+        $uploadsBase = rtrim(self::absolutePath(self::PRODUCT_DIRECTORY), '/\\') . DIRECTORY_SEPARATOR;
+        $realPath = @realpath($absolute);
+        if ($realPath && strpos($realPath, $uploadsBase) === 0 && is_file($realPath)) {
+            @unlink($realPath);
+        }
+    }
+
+    /**
+     * @return array{success:bool,message?:string,path?:string}
+     */
+    public static function runTestGeneration(): array
+    {
+        $dummyProduct = array(
+            'name' => 'Test Yazılım Paketi',
+            'duration' => '12 Ay Lisans',
+            'category' => 'Test Kategorisi',
+        );
+
+        $result = self::maybeGenerateAiImage(0, $dummyProduct);
+        if ($result['success']) {
+            self::log('Test görsel üretimi tamamlandı: ' . $result['path']);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array $file
+     * @param string $tmpName
+     * @return string
+     */
+    private static function detectMimeType(array $file, string $tmpName): string
+    {
+        $candidates = array();
+
+        if (isset($file['type']) && is_string($file['type']) && $file['type'] !== '') {
+            $candidates[] = (string) $file['type'];
+        }
+
+        if (class_exists('finfo')) {
+            $finfo = @new \finfo(FILEINFO_MIME_TYPE);
+            if ($finfo) {
+                $detected = $finfo->file($tmpName);
+                if (is_string($detected) && $detected !== '') {
+                    $candidates[] = $detected;
+                }
+            }
+        }
+
+        if (function_exists('mime_content_type')) {
+            $detected = @mime_content_type($tmpName);
+            if (is_string($detected) && $detected !== '') {
+                $candidates[] = $detected;
+            }
+        }
+
+        if (function_exists('getimagesize')) {
+            $info = @getimagesize($tmpName);
+            if ($info && isset($info['mime']) && is_string($info['mime']) && $info['mime'] !== '') {
+                $candidates[] = $info['mime'];
+            }
+        }
+
+        foreach ($candidates as $candidate) {
+            $normalized = strtolower(trim((string) $candidate));
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param string $path
+     * @return bool
+     */
+    private static function ensureDirectory(string $path): bool
+    {
+        if (is_dir($path)) {
+            return true;
+        }
+
+        return @mkdir($path, 0775, true) || is_dir($path);
+    }
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    private static function absolutePath(string $path): string
+    {
+        $root = dirname(__DIR__, 2);
+        if ($path === '') {
+            return $root;
+        }
+
+        if ($path[0] === DIRECTORY_SEPARATOR || $path[0] === '/') {
+            return $root . $path;
+        }
+
+        return $root . '/' . ltrim($path, '/');
+    }
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    private static function relativeWebPath(string $path): string
+    {
+        if ($path === '') {
+            return '';
+        }
+
+        return '/' . ltrim($path, '/');
+    }
+
+    /**
+     * @param string $message
+     * @param array<string,mixed> $context
+     * @return void
+     */
+    private static function log(string $message, array $context = array()): void
+    {
+        $logPath = self::absolutePath(self::LOG_FILE);
+        $logDir = dirname($logPath);
+        if (!self::ensureDirectory($logDir)) {
+            return;
+        }
+
+        $line = '[' . date('Y-m-d H:i:s') . '] ' . $message;
+        if ($context) {
+            $line .= ' ' . json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        @file_put_contents($logPath, $line . PHP_EOL, FILE_APPEND);
+    }
+}

--- a/app/Services/ProductOrderService.php
+++ b/app/Services/ProductOrderService.php
@@ -78,9 +78,16 @@ final class ProductOrderService
 
             $automaticDelivery = isset($product['automatic_delivery']) ? (int)$product['automatic_delivery'] === 1 : false;
 
-            if (!$automaticDelivery) {
-                $stockCheck = $pdo->prepare('SELECT COUNT(*) FROM product_stock_items WHERE product_id = :product_id AND status = "available" FOR UPDATE');
-                $stockCheck->execute(['product_id' => $productId]);
+            $usesStock = !$automaticDelivery;
+            if (!$usesStock) {
+                $stockUsageStmt = $pdo->prepare('SELECT COUNT(*) FROM product_stock_items WHERE product_id = :product_id LIMIT 1');
+                $stockUsageStmt->execute(['product_id' => $productId]);
+                $usesStock = ((int) $stockUsageStmt->fetchColumn()) > 0;
+            }
+
+            if ($usesStock) {
+                $stockCheck = $pdo->prepare('SELECT COUNT(*) FROM product_stock_items WHERE product_id = :product_id AND status = :status FOR UPDATE');
+                $stockCheck->execute(['product_id' => $productId, 'status' => 'available']);
                 $availableStock = (int)$stockCheck->fetchColumn();
                 if ($availableStock < 1) {
                     $pdo->rollBack();

--- a/app/Services/ProductStockService.php
+++ b/app/Services/ProductStockService.php
@@ -24,7 +24,7 @@ class ProductStockService
         }
 
         $pdo = Database::connection();
-        $insert = $pdo->prepare('INSERT INTO product_stock_items (product_id, content, content_hash, status, created_at) VALUES (:product_id, :content, :hash, \"available\", NOW())');
+        $insert = $pdo->prepare('INSERT INTO product_stock_items (product_id, content, content_hash, status, created_at) VALUES (:product_id, :content, :hash, :status, NOW())');
 
         $added = 0;
         $skipped = 0;
@@ -43,6 +43,7 @@ class ProductStockService
                     'product_id' => $productId,
                     'content' => $content,
                     'hash' => $hash,
+                    'status' => 'available',
                 ));
                 if ($insert->rowCount() > 0) {
                     $added++;
@@ -73,8 +74,8 @@ class ProductStockService
     public static function availableStockCount(int $productId): int
     {
         $pdo = Database::connection();
-        $stmt = $pdo->prepare('SELECT COUNT(*) FROM product_stock_items WHERE product_id = :product_id AND status = \"available\"');
-        $stmt->execute(array('product_id' => $productId));
+        $stmt = $pdo->prepare('SELECT COUNT(*) FROM product_stock_items WHERE product_id = :product_id AND status = :status');
+        $stmt->execute(array('product_id' => $productId, 'status' => 'available'));
         return (int) $stmt->fetchColumn();
     }
 
@@ -153,8 +154,8 @@ class ProductStockService
     public static function deleteStockItem(int $productId, int $stockId): bool
     {
         $pdo = Database::connection();
-        $stmt = $pdo->prepare('DELETE FROM product_stock_items WHERE id = :id AND product_id = :product_id AND status = \"available\"');
-        $stmt->execute(array('id' => $stockId, 'product_id' => $productId));
+        $stmt = $pdo->prepare('DELETE FROM product_stock_items WHERE id = :id AND product_id = :product_id AND status = :status');
+        $stmt->execute(array('id' => $stockId, 'product_id' => $productId, 'status' => 'available'));
         if ($stmt->rowCount() > 0) {
             self::logger()->info(sprintf('Ürün #%d stok kaydı #%d silindi.', $productId, $stockId));
             return true;
@@ -195,8 +196,9 @@ class ProductStockService
                 return array('success' => true, 'status' => 'completed', 'message' => 'Sipariş zaten tamamlanmış.');
             }
 
-            $stockStmt = $pdo->prepare('SELECT id, content FROM product_stock_items WHERE product_id = :product_id AND status = \"available\" ORDER BY id ASC LIMIT :limit FOR UPDATE');
+            $stockStmt = $pdo->prepare('SELECT id, content FROM product_stock_items WHERE product_id = :product_id AND status = :status ORDER BY id ASC LIMIT :limit FOR UPDATE');
             $stockStmt->bindValue(':product_id', $productId, PDO::PARAM_INT);
+            $stockStmt->bindValue(':status', 'available');
             $stockStmt->bindValue(':limit', $quantity, PDO::PARAM_INT);
             $stockStmt->execute();
             $stockRows = $stockStmt->fetchAll(PDO::FETCH_ASSOC);
@@ -215,8 +217,8 @@ class ProductStockService
             }
 
             $placeholders = implode(',', array_fill(0, count($stockIds), '?'));
-            $update = $pdo->prepare('UPDATE product_stock_items SET status = \"delivered\", order_id = ?, reserved_at = COALESCE(reserved_at, NOW()), delivered_at = NOW(), updated_at = NOW() WHERE id IN (' . $placeholders . ')');
-            $update->execute(array_merge(array($orderId), $stockIds));
+            $update = $pdo->prepare('UPDATE product_stock_items SET status = ?, order_id = ?, reserved_at = COALESCE(reserved_at, NOW()), delivered_at = NOW(), updated_at = NOW() WHERE id IN (' . $placeholders . ')');
+            $update->execute(array_merge(array('delivered', $orderId), $stockIds));
 
             $deliveryContent = implode(PHP_EOL, $contents);
 

--- a/app/Services/ProviderSyncService.php
+++ b/app/Services/ProviderSyncService.php
@@ -1,0 +1,711 @@
+<?php declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Database;
+use App\Helpers;
+use App\Settings;
+use App\Services\AnnouncementService;
+use PDO;
+use PDOException;
+use RuntimeException;
+
+final class ProviderSyncService
+{
+    private const PROVIDER_NAME = 'WooCommerce Sağlayıcı';
+    private const DEFAULT_ROOT_CATEGORY = 'Sağlayıcı Ürünleri';
+    private const MAX_PAGES = 10;
+    private const PER_PAGE = 50;
+
+    /**
+     * @return array<string,mixed>
+     */
+    public static function getSource(): array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->query('SELECT * FROM provider_sources ORDER BY id ASC LIMIT 1');
+        $source = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($source) {
+            return $source;
+        }
+
+        $insert = $pdo->prepare('INSERT INTO provider_sources (name, base_url, status, created_at) VALUES (:name, :base_url, :status, NOW())');
+        $insert->execute(array(
+            'name' => self::PROVIDER_NAME,
+            'base_url' => '',
+            'status' => 'inactive',
+        ));
+
+        $id = (int) $pdo->lastInsertId();
+        $stmt = $pdo->prepare('SELECT * FROM provider_sources WHERE id = :id LIMIT 1');
+        $stmt->execute(array('id' => $id));
+
+        return $stmt->fetch(PDO::FETCH_ASSOC) ?: array();
+    }
+
+    /**
+     * @param array<string,string> $input
+     * @return array{success:bool,message:string}
+     */
+    public static function saveCredentials(array $input): array
+    {
+        $pdo = Database::connection();
+        $source = self::getSource();
+        $id = isset($source['id']) ? (int) $source['id'] : 0;
+        if ($id <= 0) {
+            throw new RuntimeException('Sağlayıcı kaydı oluşturulamadı.');
+        }
+
+        $baseUrl = isset($input['base_url']) ? trim((string) $input['base_url']) : '';
+        $consumerKey = isset($input['consumer_key']) ? trim((string) $input['consumer_key']) : '';
+        $consumerSecret = isset($input['consumer_secret']) ? trim((string) $input['consumer_secret']) : '';
+        $status = isset($input['status']) && $input['status'] === 'active' ? 'active' : 'inactive';
+
+        if ($baseUrl !== '' && !filter_var($baseUrl, FILTER_VALIDATE_URL)) {
+            return array('success' => false, 'message' => 'Geçerli bir WordPress site adresi giriniz.');
+        }
+
+        if ($baseUrl !== '') {
+            $baseUrl = rtrim($baseUrl, '/');
+        }
+
+        $update = $pdo->prepare('UPDATE provider_sources SET name = :name, base_url = :base_url, consumer_key = :consumer_key, consumer_secret = :consumer_secret, status = :status, updated_at = NOW() WHERE id = :id');
+        $update->execute(array(
+            'name' => self::PROVIDER_NAME,
+            'base_url' => $baseUrl,
+            'consumer_key' => $consumerKey !== '' ? $consumerKey : null,
+            'consumer_secret' => $consumerSecret !== '' ? $consumerSecret : null,
+            'status' => $status,
+            'id' => $id,
+        ));
+
+        return array('success' => true, 'message' => 'Sağlayıcı ayarları güncellendi.');
+    }
+
+    /**
+     * @return array{success:bool,message:string,data?:array<string,mixed>}
+     */
+    public static function testConnection(): array
+    {
+        $source = self::getSource();
+        $response = self::request($source, 'system_status');
+
+        if (!$response['success']) {
+            return array('success' => false, 'message' => $response['message']);
+        }
+
+        $decoded = isset($response['decoded']) && is_array($response['decoded']) ? $response['decoded'] : array();
+        $environment = isset($decoded['environment']) && is_array($decoded['environment']) ? $decoded['environment'] : array();
+        $siteName = isset($environment['site_title']) ? (string) $environment['site_title'] : '';
+        $version = isset($environment['version']) ? (string) $environment['version'] : '';
+
+        $message = 'Bağlantı başarılı.';
+        if ($siteName !== '' || $version !== '') {
+            $message .= ' ' . trim(sprintf('%s %s', $siteName, $version));
+        }
+
+        return array('success' => true, 'message' => $message, 'data' => $decoded);
+    }
+
+    /**
+     * @return array{success:bool,message:string,counts?:array<string,int>}
+     */
+    public static function syncCategories(): array
+    {
+        $source = self::requireActiveSource();
+        $pdo = Database::connection();
+
+        $created = 0;
+        $updated = 0;
+        $page = 1;
+        $lastSync = date('Y-m-d H:i:s');
+
+        while ($page <= self::MAX_PAGES) {
+            $response = self::request($source, 'products/categories', array(
+                'per_page' => self::PER_PAGE,
+                'page' => $page,
+                'orderby' => 'id',
+                'order' => 'asc',
+                'hide_empty' => 'false',
+            ));
+
+            if (!$response['success']) {
+                return array('success' => false, 'message' => $response['message']);
+            }
+
+            $data = isset($response['decoded']) && is_array($response['decoded']) ? $response['decoded'] : array();
+            if (!$data) {
+                break;
+            }
+
+            foreach ($data as $category) {
+                if (!is_array($category) || !isset($category['id'])) {
+                    continue;
+                }
+
+                $remoteId = (int) $category['id'];
+                $parentRemote = isset($category['parent']) ? (int) $category['parent'] : null;
+                $name = isset($category['name']) ? trim((string) $category['name']) : '';
+                $slug = isset($category['slug']) ? trim((string) $category['slug']) : null;
+
+                $existing = self::findRemoteCategory($source['id'], $remoteId);
+                $mappedId = null;
+                if ($existing && isset($existing['mapped_category_id']) && $existing['mapped_category_id']) {
+                    $mappedId = (int) $existing['mapped_category_id'];
+                } elseif ($name !== '') {
+                    $mappedId = self::findLocalCategoryIdByName($name);
+                }
+
+                if ($existing) {
+                    $updateStmt = $pdo->prepare('UPDATE provider_remote_categories SET parent_remote_id = :parent_remote_id, name = :name, slug = :slug, last_synced_at = :last_synced_at, updated_at = NOW() WHERE id = :id');
+                    $updateStmt->execute(array(
+                        'parent_remote_id' => $parentRemote ?: null,
+                        'name' => $name,
+                        'slug' => $slug,
+                        'last_synced_at' => $lastSync,
+                        'id' => $existing['id'],
+                    ));
+
+                    if ($mappedId && (int) $existing['mapped_category_id'] !== $mappedId) {
+                        $pdo->prepare('UPDATE provider_remote_categories SET mapped_category_id = :mapped WHERE id = :id')->execute(array(
+                            'mapped' => $mappedId,
+                            'id' => $existing['id'],
+                        ));
+                    }
+                    $updated++;
+                } else {
+                    $insert = $pdo->prepare('INSERT INTO provider_remote_categories (provider_id, remote_id, parent_remote_id, name, slug, mapped_category_id, last_synced_at, created_at) VALUES (:provider_id, :remote_id, :parent_remote_id, :name, :slug, :mapped_category_id, :last_synced_at, NOW())');
+                    $insert->execute(array(
+                        'provider_id' => $source['id'],
+                        'remote_id' => $remoteId,
+                        'parent_remote_id' => $parentRemote ?: null,
+                        'name' => $name,
+                        'slug' => $slug,
+                        'mapped_category_id' => $mappedId ?: null,
+                        'last_synced_at' => $lastSync,
+                    ));
+                    $created++;
+                }
+            }
+
+            if (count($data) < self::PER_PAGE) {
+                break;
+            }
+
+            $page++;
+        }
+
+        self::touchSourceSyncTime((int) $source['id']);
+
+        return array(
+            'success' => true,
+            'message' => 'Kategoriler senkronize edildi.',
+            'counts' => array('created' => $created, 'updated' => $updated),
+        );
+    }
+
+    /**
+     * @return array{success:bool,message:string,counts?:array<string,int>,new_products?:array<int,array<string,mixed>>}
+     */
+    public static function syncProducts(): array
+    {
+        $source = self::requireActiveSource();
+        $pdo = Database::connection();
+
+        $created = 0;
+        $updated = 0;
+        $newProducts = array();
+        $page = 1;
+        $lastSync = date('Y-m-d H:i:s');
+
+        while ($page <= self::MAX_PAGES) {
+            $response = self::request($source, 'products', array(
+                'per_page' => self::PER_PAGE,
+                'page' => $page,
+                'orderby' => 'date',
+                'order' => 'desc',
+                'status' => 'publish',
+            ));
+
+            if (!$response['success']) {
+                return array('success' => false, 'message' => $response['message']);
+            }
+
+            $data = isset($response['decoded']) && is_array($response['decoded']) ? $response['decoded'] : array();
+            if (!$data) {
+                break;
+            }
+
+            foreach ($data as $product) {
+                if (!is_array($product) || !isset($product['id'])) {
+                    continue;
+                }
+
+                $remoteId = (int) $product['id'];
+                $name = isset($product['name']) ? trim((string) $product['name']) : 'Ürün';
+                $slug = isset($product['slug']) ? trim((string) $product['slug']) : null;
+                $status = isset($product['status']) ? (string) $product['status'] : null;
+                $priceField = isset($product['price']) ? $product['price'] : (isset($product['regular_price']) ? $product['regular_price'] : null);
+                $price = $priceField !== null && $priceField !== '' ? (float) $priceField : null;
+                $stockQuantity = isset($product['stock_quantity']) && $product['stock_quantity'] !== '' ? (int) $product['stock_quantity'] : null;
+                $stockStatus = isset($product['stock_status']) ? (string) $product['stock_status'] : null;
+
+                $remoteCategoryId = null;
+                $remoteCategoryName = null;
+                if (isset($product['categories']) && is_array($product['categories']) && $product['categories']) {
+                    $primaryCategory = $product['categories'][0];
+                    if (is_array($primaryCategory)) {
+                        $remoteCategoryId = isset($primaryCategory['id']) ? (int) $primaryCategory['id'] : null;
+                        $remoteCategoryName = isset($primaryCategory['name']) ? (string) $primaryCategory['name'] : null;
+                    }
+                }
+
+                $existing = self::findRemoteProduct($source['id'], $remoteId);
+
+                if ($existing) {
+                    $updateStmt = $pdo->prepare('UPDATE provider_remote_products SET name = :name, slug = :slug, price = :price, currency = :currency, status = :status, remote_category_id = :remote_category_id, remote_category_name = :remote_category_name, stock_quantity = :stock_quantity, stock_status = :stock_status, last_synced_at = :last_synced_at, updated_at = NOW() WHERE id = :id');
+                    $updateStmt->execute(array(
+                        'name' => $name,
+                        'slug' => $slug,
+                        'price' => $price,
+                        'currency' => self::detectCurrency($product),
+                        'status' => $status,
+                        'remote_category_id' => $remoteCategoryId ?: null,
+                        'remote_category_name' => $remoteCategoryName,
+                        'stock_quantity' => $stockQuantity,
+                        'stock_status' => $stockStatus,
+                        'last_synced_at' => $lastSync,
+                        'id' => $existing['id'],
+                    ));
+                    $updated++;
+                } else {
+                    $insert = $pdo->prepare('INSERT INTO provider_remote_products (provider_id, remote_id, name, slug, price, currency, status, remote_category_id, remote_category_name, stock_quantity, stock_status, last_synced_at, created_at) VALUES (:provider_id, :remote_id, :name, :slug, :price, :currency, :status, :remote_category_id, :remote_category_name, :stock_quantity, :stock_status, :last_synced_at, NOW())');
+                    $insert->execute(array(
+                        'provider_id' => $source['id'],
+                        'remote_id' => $remoteId,
+                        'name' => $name,
+                        'slug' => $slug,
+                        'price' => $price,
+                        'currency' => self::detectCurrency($product),
+                        'status' => $status,
+                        'remote_category_id' => $remoteCategoryId ?: null,
+                        'remote_category_name' => $remoteCategoryName,
+                        'stock_quantity' => $stockQuantity,
+                        'stock_status' => $stockStatus,
+                        'last_synced_at' => $lastSync,
+                    ));
+
+                    $created++;
+                    $newProducts[] = array('remote_id' => $remoteId, 'name' => $name);
+                    self::createProductAnnouncement((int) $source['id'], $remoteId, $name);
+                }
+            }
+
+            if (count($data) < self::PER_PAGE) {
+                break;
+            }
+
+            $page++;
+        }
+
+        self::touchSourceSyncTime((int) $source['id']);
+
+        return array(
+            'success' => true,
+            'message' => 'Ürünler senkronize edildi.',
+            'counts' => array('created' => $created, 'updated' => $updated),
+            'new_products' => $newProducts,
+        );
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public static function listRemoteProducts(?string $filter = null): array
+    {
+        $source = self::getSource();
+        if (!$source) {
+            return array();
+        }
+
+        $pdo = Database::connection();
+        $sql = 'SELECT prp.*, cat.name AS mapped_category_name FROM provider_remote_products prp LEFT JOIN provider_remote_categories prc ON prp.provider_id = prc.provider_id AND prp.remote_category_id = prc.remote_id LEFT JOIN categories cat ON prc.mapped_category_id = cat.id WHERE prp.provider_id = :provider_id';
+        $params = array('provider_id' => $source['id']);
+
+        if ($filter === 'unimported') {
+            $sql .= ' AND (prp.imported_product_id IS NULL OR prp.imported_product_id = 0)';
+        } elseif ($filter === 'imported') {
+            $sql .= ' AND prp.imported_product_id IS NOT NULL AND prp.imported_product_id <> 0';
+        }
+
+        $sql .= ' ORDER BY prp.updated_at DESC, prp.created_at DESC';
+
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: array();
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public static function listRemoteCategories(): array
+    {
+        $source = self::getSource();
+        if (!$source) {
+            return array();
+        }
+
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT prc.*, cat.name AS mapped_category_name FROM provider_remote_categories prc LEFT JOIN categories cat ON prc.mapped_category_id = cat.id WHERE prc.provider_id = :provider_id ORDER BY prc.name ASC');
+        $stmt->execute(array('provider_id' => $source['id']));
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: array();
+    }
+
+    /**
+     * @return array{success:bool,message:string,product_id?:int}
+     */
+    public static function importProduct(int $remoteId, int $adminId): array
+    {
+        $source = self::requireActiveSource();
+        $pdo = Database::connection();
+
+        $remote = self::findRemoteProduct($source['id'], $remoteId);
+        if (!$remote) {
+            return array('success' => false, 'message' => 'Sağlayıcıda bu ürün bulunamadı.');
+        }
+
+        if (!empty($remote['imported_product_id'])) {
+            return array('success' => false, 'message' => 'Bu ürün zaten içeri aktarılmış.');
+        }
+
+        $productResponse = self::request($source, 'products/' . $remoteId);
+        if (!$productResponse['success']) {
+            return array('success' => false, 'message' => $productResponse['message']);
+        }
+
+        $product = isset($productResponse['decoded']) && is_array($productResponse['decoded']) ? $productResponse['decoded'] : array();
+        if (!$product) {
+            return array('success' => false, 'message' => 'Ürün bilgileri alınamadı.');
+        }
+
+        $name = isset($product['name']) ? trim((string) $product['name']) : 'Sağlayıcı Ürünü';
+        $description = isset($product['description']) && $product['description'] !== ''
+            ? (string) $product['description']
+            : (isset($product['short_description']) ? (string) $product['short_description'] : '');
+        $sku = isset($product['sku']) ? trim((string) $product['sku']) : null;
+        $priceField = isset($product['price']) ? $product['price'] : (isset($product['regular_price']) ? $product['regular_price'] : null);
+        $price = $priceField !== null && $priceField !== '' ? (float) $priceField : 0.0;
+
+        $remoteCategoryId = isset($product['categories'][0]['id']) ? (int) $product['categories'][0]['id'] : (isset($remote['remote_category_id']) ? (int) $remote['remote_category_id'] : 0);
+        $categoryId = self::ensureLocalCategory((int) $source['id'], $remoteCategoryId);
+
+        $automaticDelivery = 1;
+        if (isset($product['manage_stock']) && $product['manage_stock'] === false) {
+            $automaticDelivery = 0;
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO products (category_id, name, sku, description, cost_price_try, price, status, automatic_delivery, created_at) VALUES (:category_id, :name, :sku, :description, :cost_price_try, :price, :status, :automatic_delivery, NOW())');
+        $stmt->execute(array(
+            'category_id' => $categoryId,
+            'name' => $name,
+            'sku' => $sku !== '' ? $sku : null,
+            'description' => $description,
+            'cost_price_try' => null,
+            'price' => $price,
+            'status' => 'inactive',
+            'automatic_delivery' => $automaticDelivery,
+        ));
+
+        $productId = (int) $pdo->lastInsertId();
+
+        $pdo->prepare('UPDATE provider_remote_products SET imported_product_id = :product_id, updated_at = NOW() WHERE id = :id')->execute(array(
+            'product_id' => $productId,
+            'id' => $remote['id'],
+        ));
+
+        if (!empty($remote['announcement_id'])) {
+            AnnouncementService::deactivate((int) $remote['announcement_id']);
+        }
+
+        return array('success' => true, 'message' => 'Ürün içeri aktarıldı ve taslak olarak kaydedildi.', 'product_id' => $productId);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private static function requireActiveSource(): array
+    {
+        $source = self::getSource();
+        if (!$source || empty($source['base_url'])) {
+            throw new RuntimeException('Sağlayıcı URL bilgisi eksik.');
+        }
+
+        if (empty($source['consumer_key']) || empty($source['consumer_secret'])) {
+            throw new RuntimeException('Sağlayıcı API anahtarı eksik.');
+        }
+
+        return $source;
+    }
+
+    /**
+     * @param array<string,mixed> $source
+     * @return array{success:bool,message:string,status?:int,body?:string,decoded?:mixed}
+     */
+    private static function request(array $source, string $endpoint, array $query = array(), string $method = 'GET', ?array $body = null): array
+    {
+        $baseUrl = isset($source['base_url']) ? trim((string) $source['base_url']) : '';
+        if ($baseUrl === '') {
+            return array('success' => false, 'message' => 'Sağlayıcı adresi yapılandırılmamış.');
+        }
+
+        if (empty($source['consumer_key']) || empty($source['consumer_secret'])) {
+            return array('success' => false, 'message' => 'Sağlayıcı API anahtarı eksik.');
+        }
+
+        $url = rtrim($baseUrl, '/') . '/wp-json/wc/v3/' . ltrim($endpoint, '/');
+        $query['consumer_key'] = $source['consumer_key'];
+        $query['consumer_secret'] = $source['consumer_secret'];
+
+        $url .= '?' . http_build_query($query);
+
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HEADER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json', 'User-Agent: Authero-ProviderSync/1.0'));
+
+        if (strtoupper($method) === 'POST') {
+            curl_setopt($ch, CURLOPT_POST, true);
+            if ($body !== null) {
+                curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body));
+                curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json', 'Content-Type: application/json', 'User-Agent: Authero-ProviderSync/1.0'));
+            }
+        }
+
+        $response = curl_exec($ch);
+        if ($response === false) {
+            $error = curl_error($ch);
+            curl_close($ch);
+
+            return array('success' => false, 'message' => 'Sağlayıcı isteği başarısız: ' . $error);
+        }
+
+        $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+        curl_close($ch);
+
+        $rawHeaders = substr($response, 0, $headerSize);
+        $bodyString = substr($response, $headerSize);
+
+        $decoded = json_decode((string) $bodyString, true);
+        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+            return array('success' => false, 'message' => 'API yanıtı çözümlenemedi: ' . json_last_error_msg(), 'status' => $status, 'body' => $bodyString);
+        }
+
+        if ($status < 200 || $status >= 300) {
+            $message = 'Sağlayıcı isteği başarısız (' . $status . ')';
+            if (is_array($decoded) && isset($decoded['message'])) {
+                $message .= ': ' . (string) $decoded['message'];
+            }
+
+            return array('success' => false, 'message' => $message, 'status' => $status, 'body' => $bodyString, 'decoded' => $decoded);
+        }
+
+        return array('success' => true, 'message' => 'OK', 'status' => $status, 'body' => $bodyString, 'decoded' => $decoded, 'headers' => self::parseHeaders($rawHeaders));
+    }
+
+    /**
+     * @param string $headers
+     * @return array<string,string>
+     */
+    private static function parseHeaders(string $headers): array
+    {
+        $result = array();
+        foreach (explode("\r\n", $headers) as $line) {
+            if (strpos($line, ':') === false) {
+                continue;
+            }
+            list($name, $value) = array_map('trim', explode(':', $line, 2));
+            if ($name !== '') {
+                $result[strtolower($name)] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param int $providerId
+     * @param int $remoteId
+     * @return array<string,mixed>|null
+     */
+    private static function findRemoteCategory(int $providerId, int $remoteId): ?array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT * FROM provider_remote_categories WHERE provider_id = :provider_id AND remote_id = :remote_id LIMIT 1');
+        $stmt->execute(array('provider_id' => $providerId, 'remote_id' => $remoteId));
+
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ?: null;
+    }
+
+    /**
+     * @param int $providerId
+     * @param int $remoteId
+     * @return array<string,mixed>|null
+     */
+    private static function findRemoteProduct(int $providerId, int $remoteId): ?array
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT * FROM provider_remote_products WHERE provider_id = :provider_id AND remote_id = :remote_id LIMIT 1');
+        $stmt->execute(array('provider_id' => $providerId, 'remote_id' => $remoteId));
+
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row ?: null;
+    }
+
+    private static function touchSourceSyncTime(int $providerId): void
+    {
+        $pdo = Database::connection();
+        $pdo->prepare('UPDATE provider_sources SET last_synced_at = NOW(), updated_at = NOW() WHERE id = :id')->execute(array('id' => $providerId));
+    }
+
+    private static function detectCurrency(array $product): ?string
+    {
+        if (isset($product['currency']) && $product['currency'] !== '') {
+            return (string) $product['currency'];
+        }
+
+        $defaultCurrency = Settings::get('platform_currency');
+        if ($defaultCurrency) {
+            return $defaultCurrency;
+        }
+
+        return 'TRY';
+    }
+
+    private static function findLocalCategoryIdByName(string $name): ?int
+    {
+        if ($name === '') {
+            return null;
+        }
+
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT id FROM categories WHERE LOWER(name) = LOWER(:name) LIMIT 1');
+        $stmt->execute(array('name' => $name));
+        $id = $stmt->fetchColumn();
+
+        return $id !== false ? (int) $id : null;
+    }
+
+    private static function ensureLocalCategory(int $providerId, int $remoteCategoryId): int
+    {
+        $pdo = Database::connection();
+
+        if ($remoteCategoryId <= 0) {
+            return self::ensureDefaultCategory();
+        }
+
+        $remote = self::findRemoteCategory($providerId, $remoteCategoryId);
+        if (!$remote) {
+            return self::ensureDefaultCategory();
+        }
+
+        if (!empty($remote['mapped_category_id'])) {
+            return (int) $remote['mapped_category_id'];
+        }
+
+        $parentId = isset($remote['parent_remote_id']) ? (int) $remote['parent_remote_id'] : 0;
+        $localParentId = $parentId > 0 ? self::ensureLocalCategory($providerId, $parentId) : self::ensureDefaultCategory();
+
+        $existing = self::findCategoryByNameAndParent((string) $remote['name'], $localParentId);
+        if ($existing) {
+            $pdo->prepare('UPDATE provider_remote_categories SET mapped_category_id = :mapped, updated_at = NOW() WHERE id = :id')->execute(array(
+                'mapped' => $existing,
+                'id' => $remote['id'],
+            ));
+
+            return $existing;
+        }
+
+        $insert = $pdo->prepare('INSERT INTO categories (parent_id, name, description, created_at) VALUES (:parent_id, :name, NULL, NOW())');
+        $insert->execute(array(
+            'parent_id' => $localParentId ?: null,
+            'name' => $remote['name'],
+        ));
+
+        $newId = (int) $pdo->lastInsertId();
+        $pdo->prepare('UPDATE provider_remote_categories SET mapped_category_id = :mapped, updated_at = NOW() WHERE id = :id')->execute(array(
+            'mapped' => $newId,
+            'id' => $remote['id'],
+        ));
+
+        return $newId;
+    }
+
+    private static function ensureDefaultCategory(): int
+    {
+        $pdo = Database::connection();
+        $stmt = $pdo->prepare('SELECT id FROM categories WHERE name = :name LIMIT 1');
+        $stmt->execute(array('name' => self::DEFAULT_ROOT_CATEGORY));
+        $id = $stmt->fetchColumn();
+
+        if ($id !== false) {
+            return (int) $id;
+        }
+
+        $insert = $pdo->prepare('INSERT INTO categories (parent_id, name, description, created_at) VALUES (NULL, :name, NULL, NOW())');
+        $insert->execute(array('name' => self::DEFAULT_ROOT_CATEGORY));
+
+        return (int) $pdo->lastInsertId();
+    }
+
+    private static function findCategoryByNameAndParent(string $name, int $parentId): ?int
+    {
+        $pdo = Database::connection();
+        if ($parentId > 0) {
+            $stmt = $pdo->prepare('SELECT id FROM categories WHERE parent_id = :parent_id AND name = :name LIMIT 1');
+            $stmt->execute(array('parent_id' => $parentId, 'name' => $name));
+        } else {
+            $stmt = $pdo->prepare('SELECT id FROM categories WHERE parent_id IS NULL AND name = :name LIMIT 1');
+            $stmt->execute(array('name' => $name));
+        }
+
+        $id = $stmt->fetchColumn();
+
+        return $id !== false ? (int) $id : null;
+    }
+
+    private static function createProductAnnouncement(int $providerId, int $remoteId, string $name): void
+    {
+        try {
+            $pdo = Database::connection();
+        } catch (PDOException $exception) {
+            return;
+        }
+
+        $announcementId = AnnouncementService::create(
+            'Yeni sağlayıcı ürünü: ' . $name,
+            sprintf(
+                'Yeni bir sağlayıcı ürünü bulundu: <strong>%s</strong>.<br><a href="/admin/providers.php?highlight=%d">Sağlayıcılar sayfasından hemen içeri aktarın.</a>',
+                Helpers::sanitize($name),
+                $remoteId
+            ),
+            'admin'
+        );
+
+        if ($announcementId) {
+            $update = $pdo->prepare('UPDATE provider_remote_products SET announcement_id = :announcement_id WHERE provider_id = :provider_id AND remote_id = :remote_id');
+            $update->execute(array(
+                'announcement_id' => $announcementId,
+                'provider_id' => $providerId,
+                'remote_id' => $remoteId,
+            ));
+        }
+    }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -5,47 +5,331 @@ body {
     font-family: 'Inter', 'Segoe UI', sans-serif;
 }
 
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+table {
+    width: 100%;
+}
+
+.table-responsive {
+    width: 100%;
+}
+
 .app-shell {
     display: flex;
+    flex-direction: column;
     min-height: 100vh;
     background-color: #f4f6f9;
 }
 
-.app-sidebar {
-    width: 280px;
+.navbar,
+.navbar * {
+    overflow: visible !important;
+}
+
+.app-navbar {
     background: linear-gradient(185deg, #1f3c88 0%, #151a3b 100%);
     color: #fff;
-    display: flex;
-    flex-direction: column;
-    padding: 2rem 1.75rem;
     position: sticky;
     top: 0;
-    height: 100vh;
-    overflow-y: auto;
-    box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.08);
-    transition: transform 0.3s ease;
-    transform: translateX(0);
+    z-index: 1050;
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.25);
+    padding: clamp(0.75rem, 1vw + 0.55rem, 1.25rem) 0;
 }
 
-.sidebar-brand a {
+.app-navbar-container {
+    max-width: min(1280px, 96vw);
+    margin: 0 auto;
+    padding: 0 clamp(1rem, 2vw, 2rem);
+    gap: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    width: 100%;
+    min-width: 0;
+}
+
+.app-navbar .navbar-layout {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    width: 100%;
+    min-width: 0;
+}
+
+.app-navbar .navbar-left {
+    display: flex;
+    align-items: center;
+    flex: 0 1 auto;
+    min-width: 0;
+}
+
+.app-navbar .navbar-brand {
     color: #fff;
     font-weight: 700;
-    font-size: 1.3rem;
-    text-decoration: none;
+    font-size: 1.25rem;
     letter-spacing: 0.02em;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-width: 0;
 }
 
-.sidebar-brand-tagline {
+.app-navbar .navbar-brand-logo {
+    max-height: 48px;
+    width: auto;
+    max-width: min(220px, 40vw);
+    object-fit: contain;
+    display: block;
+}
+
+.app-navbar .navbar-brand-title {
+    line-height: 1.1;
+}
+
+.app-navbar .navbar-brand:hover,
+.app-navbar .navbar-brand:focus {
+    color: #fff;
+}
+
+.app-navbar .navbar-brand-tagline {
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.app-navbar .navbar-toggler {
+    border-color: rgba(255, 255, 255, 0.4);
+    color: #fff;
+    border-radius: 0.75rem;
+    padding: 0.5rem 0.75rem;
+}
+
+.app-navbar .navbar-toggler:focus {
+    box-shadow: 0 0 0 0.25rem rgba(255, 255, 255, 0.2);
+}
+
+.app-navbar .navbar-toggler-icon {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(255,255,255,0.85)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+.app-navbar .navbar-collapse {
+    flex-grow: 1;
+    min-width: 0;
+}
+
+.navbar-collapse-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 2rem;
+    width: 100%;
+    min-width: 0;
+}
+
+.navbar-center {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.navbar-right {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+    flex: 0 1 auto;
+    min-width: 0;
+}
+
+.navbar-menu-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.25rem;
+    scrollbar-width: thin;
+}
+
+.navbar-menu-scroll::-webkit-scrollbar {
+    height: 6px;
+}
+
+.navbar-menu-scroll::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 999px;
+}
+
+@media (min-width: 992px) {
+    .app-navbar {
+        padding: clamp(0.85rem, 1vw + 0.6rem, 1.35rem) 0;
+    }
+
+    .navbar-collapse-inner {
+        flex-direction: row;
+        align-items: center;
+        gap: 1.75rem;
+    }
+
+    .navbar-right {
+        flex-direction: row;
+        align-items: center;
+        gap: 1.5rem;
+    }
+
+    .app-navbar .navbar-left {
+        flex: 0 0 auto;
+    }
+
+    .app-navbar .navbar-nav {
+        flex-direction: row;
+        width: auto;
+    }
+}
+
+.app-navbar .navbar-nav {
+    flex-wrap: nowrap;
+    gap: 0.35rem;
+    flex-direction: column;
+    width: 100%;
+}
+
+.app-navbar .nav-link {
+    color: rgba(255, 255, 255, 0.78);
+    border-radius: 0.8rem;
+    padding: 0.65rem 1rem;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    white-space: nowrap;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.app-navbar .nav-link:hover,
+.app-navbar .nav-link:focus,
+.app-navbar .nav-link.active,
+.app-navbar .nav-item.show > .nav-link {
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+}
+
+.nav-item.dropdown {
+    position: relative !important;
+    z-index: 9999;
+}
+
+.dropdown-menu {
+    position: absolute !important;
+    z-index: 9999 !important;
+}
+
+.app-navbar .dropdown-menu {
+    background: rgba(21, 26, 59, 0.97);
+    border: none;
+    border-radius: 0.85rem;
+    padding: 0.75rem 0;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.4);
+    min-width: 14rem;
+    left: 0;
+    right: auto;
+    opacity: 0;
+    transform: translateY(10px) scale(0.98);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    z-index: 9999;
     margin-top: 0.35rem;
-    font-size: 0.8rem;
-    opacity: 0.65;
 }
 
-.sidebar-user {
-    margin: 1.5rem 0 1.25rem;
-    padding: 1rem 1.1rem;
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 1rem;
+.app-navbar .dropdown-menu.dropdown-menu-end,
+.app-navbar .nav-item.dropdown .dropdown-menu-end {
+    left: auto;
+    right: 0;
+}
+
+.app-navbar .dropdown-menu.show {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+.app-navbar .dropdown-menu .dropdown-item:focus-visible,
+.app-navbar .nav-link:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.45);
+    outline-offset: 2px;
+}
+
+.navbar-menu-scroll:focus-visible {
+    outline: 2px dashed rgba(255, 255, 255, 0.35);
+    outline-offset: 4px;
+}
+
+.nav-language .form-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.nav-language .form-select {
+    min-width: 150px;
+    border-radius: 0.6rem;
+    background-color: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.nav-language .form-select option {
+    color: #111827;
+}
+
+.app-navbar .dropdown-item {
+    color: rgba(255, 255, 255, 0.78);
+    font-weight: 500;
+    padding: 0.55rem 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.app-navbar .dropdown-item:hover,
+.app-navbar .dropdown-item:focus,
+.app-navbar .dropdown-item.active {
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+}
+
+.app-navbar .dropdown-menu .dropdown-divider {
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
+.app-navbar .dropdown-menu .app-money {
+    color: inherit;
+}
+
+.menu-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.5rem;
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.22);
+    color: #fff;
+    font-size: 0.7rem;
+    font-weight: 600;
+}
+
+
+.navbar-divider {
+    width: 100%;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.18);
 }
 
 .avatar-circle {
@@ -61,157 +345,97 @@ body {
     font-size: 0.95rem;
 }
 
-.avatar-circle--sidebar {
-    width: 44px;
-    height: 44px;
-    background: rgba(255, 255, 255, 0.2);
+.avatar-circle--navbar {
+    width: 42px;
+    height: 42px;
+    background: rgba(255, 255, 255, 0.25);
     color: #ffffff;
     font-size: 1rem;
 }
 
-.sidebar-user-name {
-    font-size: 1.05rem;
+.navbar-balance-label {
+    letter-spacing: 0.08em;
 }
 
-.sidebar-user-role {
-    letter-spacing: 0.12em;
-    font-size: 0.7rem;
-    opacity: 0.7;
-}
-
-.sidebar-user-balance {
-    font-size: 0.85rem;
-}
-
-.text-white-75 {
-    color: rgba(255, 255, 255, 0.75) !important;
-}
-
-.sidebar-nav {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    flex: 1;
-}
-
-.sidebar-section {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-}
-
-.sidebar-section-heading {
-    font-size: 0.72rem;
-    letter-spacing: 0.18em;
-    padding-left: 0.35rem;
-    opacity: 0.7;
-}
-
-.sidebar-section-list {
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.55rem;
-}
-
-.sidebar-link {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem 1rem;
-    border-radius: 0.8rem;
-    color: rgba(255, 255, 255, 0.78);
-    text-decoration: none;
-    font-weight: 500;
-    transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
-}
-
-.sidebar-link-icon {
-    width: 1.5rem;
-    display: inline-flex;
-    justify-content: center;
-    font-size: 1rem;
-}
-
-.sidebar-link-badge {
-    margin-left: auto;
-    background: rgba(255, 255, 255, 0.18);
-    border-radius: 999px;
-    font-size: 0.7rem;
-    padding: 0.1rem 0.5rem;
+.navbar-balance-amount .app-money {
+    color: #fff;
     font-weight: 600;
+}
+
+.btn-navbar-profile {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.45rem 0.75rem;
     color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    font-weight: 500;
 }
 
-.sidebar-link:hover,
-.sidebar-link:focus,
-.sidebar-link.active {
-    background: rgba(255, 255, 255, 0.18);
+.btn-navbar-profile:hover,
+.btn-navbar-profile:focus {
     color: #fff;
-    transform: translateX(4px);
+    background: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.35);
+    box-shadow: 0 0 0 0.15rem rgba(255, 255, 255, 0.15);
 }
 
-.sidebar-footer {
-    margin-top: 2rem;
+.navbar-avatar-initial {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.25);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.95rem;
+    text-transform: uppercase;
 }
 
-.sidebar-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(15, 23, 42, 0.45);
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.3s ease, visibility 0.3s ease;
-    z-index: 1040;
+.navbar-avatar-image {
+    width: 36px;
+    height: 36px;
+    object-fit: cover;
+    border: 2px solid rgba(255, 255, 255, 0.35);
 }
 
-body.sidebar-open {
-    overflow: hidden;
+.navbar-profile-dropdown .dropdown-menu {
+    min-width: 16rem;
 }
 
-body.sidebar-open .sidebar-backdrop {
-    opacity: 1;
-    visibility: visible;
+.navbar-profile-dropdown .dropdown-item i {
+    color: rgba(255, 255, 255, 0.75);
 }
 
-body.sidebar-open .app-sidebar {
-    transform: translateX(0);
+.navbar-profile-dropdown .dropdown-item.text-danger i {
+    color: rgba(255, 71, 87, 0.95);
 }
 
 .app-main {
     flex: 1;
     display: flex;
     flex-direction: column;
-    min-height: 100vh;
+    min-height: 0;
 }
 
 .app-topbar {
     background: #ffffff;
     border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-    padding: 1.5rem 2rem;
+    padding: 1.5rem 0;
+}
+
+.app-topbar-inner {
+    width: 100%;
+    max-width: min(1280px, 96vw);
+    margin: 0 auto;
+    padding: 0 clamp(1.25rem, 2vw, 2rem);
 }
 
 .app-topbar-actions {
     gap: 1rem;
-}
-
-.sidebar-toggle {
-    width: 2.75rem;
-    height: 2.75rem;
-    border-radius: 0.75rem;
-    display: inline-flex !important;
-    align-items: center;
-    justify-content: center;
-    color: #1f3c88;
-    background-color: #eef2ff;
-    box-shadow: 0 8px 16px rgba(31, 60, 136, 0.15);
-}
-
-.sidebar-toggle:hover,
-.sidebar-toggle:focus {
-    color: #fff;
-    background-color: #1f3c88;
 }
 
 .app-language-switcher select {
@@ -235,9 +459,9 @@ body.sidebar-open .app-sidebar {
 
 .app-container {
     width: 100%;
-    max-width: 1320px;
+    max-width: min(1280px, 96vw);
     margin: 0 auto;
-    padding: 0 1.5rem;
+    padding: 0 clamp(1.25rem, 2vw, 2rem);
 }
 
 .app-footer {
@@ -300,51 +524,81 @@ body.sidebar-open .app-sidebar {
 }
 
 @media (max-width: 991.98px) {
-    .app-shell {
+    .app-navbar-container {
+        padding: 0 clamp(0.75rem, 2vw, 1.5rem);
+    }
+
+    .app-topbar-inner {
+        padding: 0 clamp(1rem, 2.5vw, 1.5rem);
+    }
+
+    .navbar-right {
+        align-items: stretch !important;
+        width: 100%;
+        padding-top: 0.5rem;
+    }
+
+    .nav-language .form-select {
+        width: 100%;
+    }
+
+    .navbar-center {
+        width: 100%;
+    }
+
+    .app-navbar .navbar-nav {
         flex-direction: column;
+        align-items: stretch;
+        gap: 0.5rem;
     }
 
-    .app-sidebar {
-        position: fixed;
-        left: 0;
-        top: 0;
-        bottom: 0;
-        transform: translateX(-105%);
-        max-width: 80vw;
-        z-index: 1050;
+    .app-navbar .nav-link {
+        width: 100%;
+        justify-content: flex-start;
     }
 
-    .app-topbar {
-        padding: 1.25rem 1.5rem;
+    .navbar-menu-scroll {
+        overflow-x: visible;
+        padding-bottom: 0;
     }
 
-    .app-container {
-        padding: 0 1.25rem;
+    .app-navbar .dropdown-menu {
+        position: static !important;
+        margin-top: 0;
+        box-shadow: none;
+        width: 100%;
+        opacity: 1;
+        transform: none;
+        background: rgba(21, 26, 59, 0.92);
+    }
+
+    .app-navbar .dropdown-menu.show {
+        transform: none;
     }
 }
 
 @media (max-width: 767.98px) {
-    .app-topbar {
-        padding: 1rem 1.2rem;
-    }
-
     .app-page-header {
         padding: 1.25rem 1.35rem;
         border-radius: 1rem;
     }
 
-    .app-container {
-        padding: 0 1rem;
+    .app-navbar-container {
+        padding: 0 clamp(0.5rem, 4vw, 1rem);
+    }
+
+    .app-topbar-inner {
+        padding: 0 clamp(0.75rem, 4vw, 1.25rem);
     }
 }
 
 @media (max-width: 575.98px) {
-    .app-topbar {
-        padding: 0.9rem 1rem;
+    .navbar-right {
+        gap: 0.75rem;
     }
 
-    .app-container {
-        padding: 0 0.75rem;
+    .navbar-balance {
+        text-align: left !important;
     }
 }
 
@@ -362,37 +616,7 @@ body.sidebar-open .app-sidebar {
     box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
     padding: 2.5rem;
     width: 100%;
-    max-width: 430px;
-}
-
-.sidebar-toggle {
-    width: 2.75rem;
-    height: 2.75rem;
-    border-radius: 0.75rem;
-    display: inline-flex !important;
-    align-items: center;
-    justify-content: center;
-    color: #1f3c88;
-    background-color: #eef2ff;
-    box-shadow: 0 8px 16px rgba(31, 60, 136, 0.15);
-    border: 0;
-}
-
-.sidebar-toggle:hover,
-.sidebar-toggle:focus {
-    color: #fff;
-    background-color: #1f3c88;
-}
-
-.sidebar-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(15, 23, 42, 0.4);
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.3s ease, visibility 0.3s ease;
-    z-index: 1040;
-    cursor: pointer;
+    max-width: min(430px, 92vw);
 }
 
 .package-grid {
@@ -681,19 +905,6 @@ body.sidebar-open .app-sidebar {
     border-color: #bcdfff;
 }
 
-body.sidebar-open {
-    overflow: hidden;
-}
-
-body.sidebar-open .sidebar-backdrop {
-    opacity: 1;
-    visibility: visible;
-}
-
-body.sidebar-open .app-sidebar {
-    transform: translateX(0);
-}
-
 @media (max-width: 1199.98px) {
     .app-topbar h1 {
         font-size: 1.25rem;
@@ -792,7 +1003,7 @@ body.sidebar-open .app-sidebar {
 
 .catalog-search-form {
     width: 100%;
-    max-width: 320px;
+    max-width: min(320px, 100%);
 }
 
 .catalog-search {
@@ -966,20 +1177,48 @@ body.sidebar-open .app-sidebar {
 
 .product-card {
     background: #fff;
+    background: #ffffff;
     border: 1px solid #dfe4f2;
     border-radius: 1rem;
-    padding: 1.1rem;
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    height: 100%;
+    overflow: hidden;
     box-shadow: 0 8px 20px rgba(15, 35, 95, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.product-card__header {
+.product-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 14px 30px rgba(31, 60, 136, 0.12);
+}
+
+.product-card__media {
+    position: relative;
+    overflow: hidden;
+    background: #f5f7fb;
+}
+
+.product-card__media img {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+    display: block;
+}
+
+.product-card__body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 1.2rem;
+    gap: 0.75rem;
+}
+
+.product-card__top {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: 0.75rem;
+    gap: 1rem;
 }
 
 .product-card__title {
@@ -989,18 +1228,23 @@ body.sidebar-open .app-sidebar {
     color: #1f3c88;
 }
 
-.product-card__category {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: #9aa5bf;
-    margin-top: 0.35rem;
+.product-card__duration {
+    font-weight: 500;
+    color: #4d5771;
+    font-size: 0.85rem;
+    margin-left: 0.4rem;
 }
 
 .product-card__price {
     font-weight: 700;
     color: #1f3c88;
     font-size: 1.05rem;
+    white-space: nowrap;
+}
+
+.product-card__meta-line {
+    font-size: 0.8rem;
+    color: #6c7a91;
 }
 
 .product-card__sku {
@@ -1008,14 +1252,30 @@ body.sidebar-open .app-sidebar {
     color: #6c7a91;
 }
 
-.product-card__stock {
-    margin: 0.25rem 0 0.5rem;
+.product-card__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
 }
 
-.product-card__stock .badge {
+.product-card__badges .badge {
     font-size: 0.75rem;
     font-weight: 600;
     padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+}
+
+.product-card__stock {
+    font-size: 0.85rem;
+    color: #1f3c88;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.product-card__stock-detail {
+    font-size: 0.75rem;
+    color: #6c7a91;
 }
 
 .product-card__description {
@@ -1025,29 +1285,31 @@ body.sidebar-open .app-sidebar {
     line-height: 1.5;
 }
 
+.product-card__hint {
+    font-size: 0.75rem;
+    color: #a2672a;
+    background: #fff4e2;
+    border-radius: 0.75rem;
+    padding: 0.6rem 0.8rem;
+}
+
 .product-card__actions {
     display: flex;
-    justify-content: flex-end;
+    justify-content: flex-start;
+    gap: 0.5rem;
+    margin-top: auto;
 }
 
 .catalog-products {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 1.5rem;
+    margin: 0;
 }
 
-@media (max-width: 1199.98px) {
-    .catalog-products {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 1.5rem;
-    }
+.catalog-products > [class*='col-'] {
+    display: flex;
 }
 
-@media (max-width: 991.98px) {
-    .catalog-products {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 1.25rem;
-    }
+.catalog-products .product-card {
+    width: 100%;
 }
 
 @media (max-width: 575.98px) {
@@ -1058,10 +1320,6 @@ body.sidebar-open .app-sidebar {
 
     .catalog-section--products {
         max-width: 100%;
-    }
-
-    .catalog-products {
-        grid-template-columns: 1fr;
     }
 }
 

--- a/assets/logo-default.svg
+++ b/assets/logo-default.svg
@@ -1,0 +1,13 @@
+<svg width="160" height="40" viewBox="0 0 160 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="40" rx="12" fill="url(#gradient)"/>
+  <path d="M29 13H23V27H29C33.4183 27 37 23.4183 37 19C37 14.5817 33.4183 13 29 13Z" fill="white" opacity="0.25"/>
+  <path d="M20 27H12.5C11.6716 27 11 26.3284 11 25.5V14.5C11 13.6716 11.6716 13 12.5 13H20C23.5899 13 26.5 15.9101 26.5 19.5C26.5 23.0899 23.5899 27 20 27Z" fill="white"/>
+  <text x="52" y="24" fill="white" font-family="'Inter', 'Segoe UI', sans-serif" font-size="14" font-weight="600">Bayi Yönetim</text>
+  <text x="52" y="33" fill="rgba(255,255,255,0.65)" font-family="'Inter', 'Segoe UI', sans-serif" font-size="10">Otomasyon Paneli</text>
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="160" y2="40" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#1f3c88"/>
+      <stop offset="100%" stop-color="#151a3b"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/assets/no-image.svg
+++ b/assets/no-image.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="450" viewBox="0 0 800 450" role="img" aria-labelledby="title desc">
+  <title id="title">Görsel mevcut değil</title>
+  <desc id="desc">Ürün görseli henüz eklenmediği için yer tutucu</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1b3c73" />
+      <stop offset="100%" stop-color="#2f5fb3" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)" rx="24" />
+  <g fill="none" stroke="#ffffff" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" opacity="0.8">
+    <path d="M250 140h300a30 30 0 0 1 30 30v210a30 30 0 0 1-30 30H250a30 30 0 0 1-30-30V170a30 30 0 0 1 30-30z" />
+    <circle cx="320" cy="220" r="38" />
+    <path d="M230 360l110-110 80 80 70-70 90 100" />
+  </g>
+  <text x="400" y="400" fill="#ffffff" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="36" text-anchor="middle" opacity="0.85">
+    Görsel mevcut değil
+  </text>
+</svg>

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,9 +1,144 @@
-<?php declare(strict_types=1);
+<?php
+
+if (!function_exists('hash_equals')) {
+    function hash_equals($knownString, $userString)
+    {
+        if (!is_string($knownString) || !is_string($userString)) {
+            return false;
+        }
+
+        if (strlen($knownString) !== strlen($userString)) {
+            return false;
+        }
+
+        $result = 0;
+        $length = strlen($knownString);
+
+        for ($i = 0; $i < $length; $i++) {
+            $result |= ord($knownString[$i]) ^ ord($userString[$i]);
+        }
+
+        return $result === 0;
+    }
+}
+
+if (!function_exists('random_bytes')) {
+    function random_bytes($length)
+    {
+        if (!is_int($length) || $length < 1) {
+            throw new Exception('random_bytes(): Length must be a positive integer');
+        }
+
+        if (function_exists('openssl_random_pseudo_bytes')) {
+            $strong = false;
+            $bytes = openssl_random_pseudo_bytes($length, $strong);
+            if (is_string($bytes) && strlen($bytes) === $length) {
+                return $bytes;
+            }
+        }
+
+        $random = '';
+        if (is_readable('/dev/urandom')) {
+            $handle = @fopen('/dev/urandom', 'rb');
+            if ($handle) {
+                $random = fread($handle, $length);
+                fclose($handle);
+                if (is_string($random) && strlen($random) === $length) {
+                    return $random;
+                }
+            }
+        }
+
+        if (function_exists('mt_rand')) {
+            for ($i = 0; $i < $length; $i++) {
+                $random .= chr(mt_rand(0, 255));
+            }
+
+            if (strlen($random) === $length) {
+                return $random;
+            }
+        }
+
+        throw new Exception('random_bytes(): no suitable CSPRNG available');
+    }
+}
 
 $rootPath = __DIR__;
 
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_start();
+}
+
+if (!defined('APP_ERROR_LOG_INITIALIZED')) {
+    $logDirectory = $rootPath . '/admin';
+    $logFile = $logDirectory . '/error.log';
+
+    if (!defined('APP_ERROR_LOG_PATH')) {
+        define('APP_ERROR_LOG_PATH', $logFile);
+    }
+
+    if (!is_dir($logDirectory)) {
+        @mkdir($logDirectory, 0775, true);
+    }
+
+    if (!is_file($logFile)) {
+        @touch($logFile);
+        if (is_file($logFile)) {
+            @chmod($logFile, 0664);
+        }
+    }
+
+    if (is_writable($logFile) || is_writable($logDirectory)) {
+        error_reporting(E_ALL);
+        ini_set('display_errors', '0');
+        ini_set('log_errors', '1');
+        ini_set('error_log', $logFile);
+
+        $formatter = static function ($type, $message, $file = null, $line = null) {
+            $timestamp = date('Y-m-d H:i:s');
+            $location = '';
+            if ($file !== null) {
+                $location = ' in ' . $file;
+                if ($line !== null) {
+                    $location .= ':' . $line;
+                }
+            }
+
+            return sprintf('[%s] %s: %s%s', $timestamp, $type, $message, $location);
+        };
+
+        set_error_handler(static function ($severity, $message, $file = null, $line = null) use ($formatter) {
+            if (!(error_reporting() & $severity)) {
+                return false;
+            }
+
+            error_log($formatter('PHP Error', $message, $file, $line));
+            return false;
+        });
+
+        set_exception_handler(static function ($throwable) use ($formatter) {
+            $isThrowable = $throwable instanceof Exception;
+            if (!$isThrowable && class_exists('Throwable')) {
+                $isThrowable = is_a($throwable, 'Throwable');
+            }
+
+            if ($isThrowable && is_object($throwable)) {
+                error_log($formatter('Uncaught Exception', $throwable->getMessage(), $throwable->getFile(), $throwable->getLine()));
+                return;
+            }
+
+            error_log($formatter('Uncaught Error', is_object($throwable) ? get_class($throwable) : (string) $throwable));
+        });
+
+        register_shutdown_function(static function () use ($formatter) {
+            $error = error_get_last();
+            if ($error !== null) {
+                error_log($formatter('Shutdown Error', (string) $error['message'], $error['file'], (int) $error['line']));
+            }
+        });
+
+        define('APP_ERROR_LOG_INITIALIZED', true);
+    }
 }
 
 $forwardedScheme = null;
@@ -30,7 +165,7 @@ if (is_file($composerAutoload)) {
     require_once $composerAutoload;
 }
 
-spl_autoload_register(static function ($class) use ($rootPath): void {
+spl_autoload_register(static function ($class) use ($rootPath) {
     $prefix = 'App\\';
     $length = strlen($prefix);
 
@@ -55,20 +190,33 @@ spl_autoload_register(static function ($class) use ($rootPath): void {
 });
 
 if (!function_exists('envStr')) {
-    function envStr(string $key, ?string $default = null): ?string
+    function envStr($key, $default = null)
     {
-        return $_ENV[$key] ?? $_SERVER[$key] ?? $default;
+        if (isset($_ENV[$key])) {
+            return $_ENV[$key];
+        }
+
+        if (isset($_SERVER[$key])) {
+            return $_SERVER[$key];
+        }
+
+        return $default;
     }
 }
 
-if (class_exists(\Dotenv\Dotenv::class)) {
+if (class_exists('\\Dotenv\\Dotenv')) {
     \Dotenv\Dotenv::createImmutable($rootPath)->safeLoad();
 } elseif (is_file($rootPath . '/env.php')) {
     /** @noinspection PhpIncludeInspection */
     require_once $rootPath . '/env.php';
 }
 
-@mkdir($rootPath . '/storage', 0777, true);
+$storageDirectory = $rootPath . '/storage';
+if (!is_dir($storageDirectory)) {
+    if (!@mkdir($storageDirectory, 0777, true) && !is_dir($storageDirectory)) {
+        error_log('[Bootstrap] Depolama dizini oluşturulamadı: ' . $storageDirectory);
+    }
+}
 
 $configPath = $rootPath . '/config/config.php';
 if (is_file($configPath)) {
@@ -88,7 +236,7 @@ if ($dbName !== '') {
             'user' => $dbUser,
             'password' => $dbPassword,
         ));
-    } catch (\Throwable $connectionException) {
+    } catch (Exception $connectionException) {
         error_log('[Bootstrap] Veritabanı bağlantısı kurulamadı: ' . $connectionException->getMessage());
     }
 }
@@ -96,7 +244,7 @@ if ($dbName !== '') {
 if (class_exists(App\Migrations\Schema::class)) {
     try {
         App\Migrations\Schema::ensure();
-    } catch (\Throwable $schemaException) {
+    } catch (Exception $schemaException) {
         error_log('[Bootstrap] Şema güncellenemedi: ' . $schemaException->getMessage());
     }
 }
@@ -115,7 +263,7 @@ if (!empty($_SESSION['user']) && isset($_SESSION['user']['id'])) {
                 unset($_SESSION['user']);
             }
         }
-    } catch (\Throwable $refreshException) {
+    } catch (Exception $refreshException) {
         error_log('[Bootstrap] Oturum kullanıcısı yenilenemedi: ' . $refreshException->getMessage());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "type": "project",
   "require": {
     "php": "^8.1",
-    "guzzlehttp/guzzle": "^7.9",
     "vlucas/phpdotenv": "^5.6"
   },
   "autoload": {

--- a/index.php
+++ b/index.php
@@ -225,6 +225,9 @@ $flashWarning = isset($_SESSION['flash_warning']) ? $_SESSION['flash_warning'] :
 unset($_SESSION['flash_success'], $_SESSION['flash_warning']);
 
 $errors = array();
+$googleClientId = Settings::get('google_oauth_client_id');
+$googleClientSecret = Settings::get('google_oauth_client_secret');
+$googleLoginEnabled = $googleClientId && $googleClientSecret;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!Helpers::verifyCsrf(isset($_POST['csrf_token']) ? $_POST['csrf_token'] : '')) {
@@ -582,18 +585,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <button type="submit" class="btn-primary">Giriş Yap</button>
                 </form>
                 
-                <!-- OAuth butonları (isteğe bağlı) -->
-                <!--
-                <button type="button" class="btn-secondary">
-                    <div class="google-icon"></div>
-                    Google ile Giriş Yap
-                </button>
-                
-                <button type="button" class="btn-secondary">
-                    <div class="facebook-icon"></div>
-                    Facebook ile Giriş Yap
-                </button>
-                -->
+                <?php if ($googleLoginEnabled): ?>
+                    <a class="btn-secondary" href="/oauth/google.php" style="text-decoration: none; display: flex; align-items: center; justify-content: center; gap: 0.75rem;">
+                        <div class="google-icon"></div>
+                        Google ile Giriş Yap
+                    </a>
+                <?php endif; ?>
             </div>
         </div>
         

--- a/integrations/woocommerce/postman_collection.json
+++ b/integrations/woocommerce/postman_collection.json
@@ -1,0 +1,149 @@
+{
+  "info": {
+    "_postman_id": "5f4bde80-7f9f-4fd1-a3cb-woo-commerce",
+    "name": "WooCommerce Sağlayıcı Entegrasyonu",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "WooCommerce REST API üzerinden ürün ve kategori senkronizasyonu için örnek istekler."
+  },
+  "item": [
+    {
+      "name": "Kullanıcı Bilgisi",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/wp-json/wc/v3/customers/me?consumer_key={{consumer_key}}&consumer_secret={{consumer_secret}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "wp-json",
+            "wc",
+            "v3",
+            "customers",
+            "me"
+          ],
+          "query": [
+            {
+              "key": "consumer_key",
+              "value": "{{consumer_key}}"
+            },
+            {
+              "key": "consumer_secret",
+              "value": "{{consumer_secret}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Ürün Listesi",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/wp-json/wc/v3/products?per_page=25&page=1&consumer_key={{consumer_key}}&consumer_secret={{consumer_secret}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "wp-json",
+            "wc",
+            "v3",
+            "products"
+          ],
+          "query": [
+            {
+              "key": "per_page",
+              "value": "25"
+            },
+            {
+              "key": "page",
+              "value": "1"
+            },
+            {
+              "key": "status",
+              "value": "publish"
+            },
+            {
+              "key": "consumer_key",
+              "value": "{{consumer_key}}"
+            },
+            {
+              "key": "consumer_secret",
+              "value": "{{consumer_secret}}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Kategori Listesi",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/wp-json/wc/v3/products/categories?per_page=50&page=1&consumer_key={{consumer_key}}&consumer_secret={{consumer_secret}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "wp-json",
+            "wc",
+            "v3",
+            "products",
+            "categories"
+          ],
+          "query": [
+            {
+              "key": "per_page",
+              "value": "50"
+            },
+            {
+              "key": "page",
+              "value": "1"
+            },
+            {
+              "key": "consumer_key",
+              "value": "{{consumer_key}}"
+            },
+            {
+              "key": "consumer_secret",
+              "value": "{{consumer_secret}}"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://example.com"
+    },
+    {
+      "key": "consumer_key",
+      "value": "ck_xxxxxxxxxxxxxxxxxxxxx"
+    },
+    {
+      "key": "consumer_secret",
+      "value": "cs_xxxxxxxxxxxxxxxxxxxxx"
+    }
+  ]
+}

--- a/oauth/google.php
+++ b/oauth/google.php
@@ -1,0 +1,192 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+use App\Auth;
+use App\Helpers;
+use App\Lang;
+use App\Settings;
+
+$clientId = Settings::get('google_oauth_client_id');
+$clientSecret = Settings::get('google_oauth_client_secret');
+
+if (!$clientId || !$clientSecret) {
+    $_SESSION['flash_warning'] = 'Google ile giriş özelliği yapılandırılmamış.';
+    Helpers::redirect('/');
+}
+
+$redirectUri = Helpers::url('oauth/google.php', true);
+$step = isset($_GET['step']) ? (string) $_GET['step'] : '';
+
+if ($step === 'callback') {
+    handleCallback($clientId, $clientSecret, $redirectUri);
+    return;
+}
+
+startAuthorization($clientId, $redirectUri);
+
+function startAuthorization(string $clientId, string $redirectUri): void
+{
+    $state = bin2hex(random_bytes(16));
+    $_SESSION['google_oauth_state'] = $state;
+
+    $params = array(
+        'client_id' => $clientId,
+        'redirect_uri' => $redirectUri,
+        'response_type' => 'code',
+        'scope' => 'openid email profile',
+        'state' => $state,
+        'access_type' => 'online',
+        'prompt' => 'select_account',
+    );
+
+    $authUrl = 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build_query($params);
+    header('Location: ' . $authUrl);
+    exit;
+}
+
+function handleCallback(string $clientId, string $clientSecret, string $redirectUri): void
+{
+    $state = isset($_GET['state']) ? (string) $_GET['state'] : '';
+    $storedState = isset($_SESSION['google_oauth_state']) ? (string) $_SESSION['google_oauth_state'] : '';
+    unset($_SESSION['google_oauth_state']);
+
+    if ($state === '' || $storedState === '' || !hash_equals($storedState, $state)) {
+        $_SESSION['flash_warning'] = 'Güvenlik doğrulaması başarısız oldu. Lütfen tekrar deneyin.';
+        Helpers::redirect('/');
+    }
+
+    if (isset($_GET['error'])) {
+        $error = (string) $_GET['error'];
+        $_SESSION['flash_warning'] = 'Google oturumu iptal edildi: ' . $error;
+        Helpers::redirect('/');
+    }
+
+    $code = isset($_GET['code']) ? (string) $_GET['code'] : '';
+    if ($code === '') {
+        $_SESSION['flash_warning'] = 'Google tarafından geçerli bir yetkilendirme kodu gönderilmedi.';
+        Helpers::redirect('/');
+    }
+
+    $tokenResponse = exchangeCodeForToken($code, $clientId, $clientSecret, $redirectUri);
+    if (!$tokenResponse['success']) {
+        $_SESSION['flash_warning'] = $tokenResponse['message'];
+        Helpers::redirect('/');
+    }
+
+    $accessToken = $tokenResponse['access_token'];
+    $userInfo = fetchUserInfo($accessToken);
+    if (!$userInfo['success']) {
+        $_SESSION['flash_warning'] = $userInfo['message'];
+        Helpers::redirect('/');
+    }
+
+    $profile = $userInfo['profile'];
+    $email = isset($profile['email']) ? strtolower(trim((string) $profile['email'])) : '';
+    $emailVerified = isset($profile['email_verified']) ? (bool) $profile['email_verified'] : true;
+
+    if ($email === '') {
+        $_SESSION['flash_warning'] = 'Google hesabından e-posta bilgisi alınamadı.';
+        Helpers::redirect('/');
+    }
+
+    if (!$emailVerified) {
+        $_SESSION['flash_warning'] = 'Google hesabınız doğrulanmamış görünüyor. Lütfen önce hesabınızı doğrulayın.';
+        Helpers::redirect('/');
+    }
+
+    $user = Auth::findActiveUserByEmail($email);
+    if (!$user) {
+        $_SESSION['flash_warning'] = 'Bu e-posta adresiyle kayıtlı aktif bayi bulunamadı.';
+        Helpers::redirect('/');
+    }
+
+    $_SESSION['user'] = $user;
+
+    $preferredLanguage = Settings::get('user_' . $user['id'] . '_preferred_language');
+    if ($preferredLanguage) {
+        Lang::setLocale($preferredLanguage);
+    } else {
+        Lang::boot();
+    }
+
+    $redirectTarget = Auth::isAdminRole($user['role']) ? '/admin/dashboard.php' : '/dashboard.php';
+    Helpers::redirect($redirectTarget);
+}
+
+/**
+ * @return array{success:bool,message:string,access_token?:string}
+ */
+function exchangeCodeForToken(string $code, string $clientId, string $clientSecret, string $redirectUri): array
+{
+    $payload = array(
+        'code' => $code,
+        'client_id' => $clientId,
+        'client_secret' => $clientSecret,
+        'redirect_uri' => $redirectUri,
+        'grant_type' => 'authorization_code',
+    );
+
+    $ch = curl_init('https://oauth2.googleapis.com/token');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded'));
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($payload));
+
+    $response = curl_exec($ch);
+    if ($response === false) {
+        $error = curl_error($ch);
+        curl_close($ch);
+        return array('success' => false, 'message' => 'Google token isteği başarısız: ' . $error);
+    }
+
+    $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    curl_close($ch);
+
+    $decoded = json_decode((string) $response, true);
+    if (!is_array($decoded)) {
+        return array('success' => false, 'message' => 'Google token yanıtı çözümlenemedi.');
+    }
+
+    if ($status < 200 || $status >= 300) {
+        $message = isset($decoded['error_description']) ? (string) $decoded['error_description'] : 'Yetkilendirme sırasında hata oluştu.';
+        return array('success' => false, 'message' => $message);
+    }
+
+    if (empty($decoded['access_token'])) {
+        return array('success' => false, 'message' => 'Google erişim anahtarı alınamadı.');
+    }
+
+    return array('success' => true, 'message' => 'OK', 'access_token' => (string) $decoded['access_token']);
+}
+
+/**
+ * @return array{success:bool,message:string,profile?:array<string,mixed>}
+ */
+function fetchUserInfo(string $accessToken): array
+{
+    $ch = curl_init('https://www.googleapis.com/oauth2/v3/userinfo');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Bearer ' . $accessToken, 'Accept: application/json'));
+
+    $response = curl_exec($ch);
+    if ($response === false) {
+        $error = curl_error($ch);
+        curl_close($ch);
+        return array('success' => false, 'message' => 'Google kullanıcı bilgileri alınamadı: ' . $error);
+    }
+
+    $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    curl_close($ch);
+
+    $decoded = json_decode((string) $response, true);
+    if (!is_array($decoded)) {
+        return array('success' => false, 'message' => 'Google kullanıcı bilgileri çözümlenemedi.');
+    }
+
+    if ($status < 200 || $status >= 300) {
+        $message = isset($decoded['error_description']) ? (string) $decoded['error_description'] : 'Google kullanıcı bilgileri alınamadı.';
+        return array('success' => false, 'message' => $message);
+    }
+
+    return array('success' => true, 'message' => 'OK', 'profile' => $decoded);
+}

--- a/products.php
+++ b/products.php
@@ -58,8 +58,12 @@ try {
         $favoritePlaceholders = implode(',', array_fill(0, count($favoriteProductIds), '?'));
         $favoriteQuery = 'SELECT pr.*, cat.name AS category_name, (
                 SELECT COUNT(*) FROM product_stock_items psi
-                WHERE psi.product_id = pr.id AND psi.status = "available"
-            ) AS available_stock
+                WHERE psi.product_id = pr.id AND psi.status = \'available\'
+            ) AS available_stock,
+            (
+                SELECT COUNT(*) FROM product_stock_items psi_all
+                WHERE psi_all.product_id = pr.id
+            ) AS total_stock_items
             FROM products pr
             INNER JOIN categories cat ON pr.category_id = cat.id
             WHERE pr.status = ? AND pr.id IN (' . $favoritePlaceholders . ')
@@ -254,7 +258,10 @@ try {
         }
 
         $placeholders = implode(',', array_fill(0, count($categoryIds), '?'));
-        $productsQuery = 'SELECT pr.*, cat.name AS category_name, (SELECT COUNT(*) FROM product_stock_items psi WHERE psi.product_id = pr.id AND psi.status = "available") AS available_stock FROM products pr INNER JOIN categories cat ON pr.category_id = cat.id WHERE pr.status = ? AND pr.category_id IN (' . $placeholders . ')';
+        $productsQuery = 'SELECT pr.*, cat.name AS category_name,
+            (SELECT COUNT(*) FROM product_stock_items psi WHERE psi.product_id = pr.id AND psi.status = \'available\') AS available_stock,
+            (SELECT COUNT(*) FROM product_stock_items psi_all WHERE psi_all.product_id = pr.id) AS total_stock_items
+            FROM products pr INNER JOIN categories cat ON pr.category_id = cat.id WHERE pr.status = ? AND pr.category_id IN (' . $placeholders . ')';
         $productParams = array_merge(['active'], $categoryIds);
 
         if ($searchTerm !== '') {
@@ -269,7 +276,10 @@ try {
         $products = $productsStmt->fetchAll();
     } else {
         if ($searchTerm !== '') {
-            $productsQuery = 'SELECT pr.*, cat.name AS category_name, (SELECT COUNT(*) FROM product_stock_items psi WHERE psi.product_id = pr.id AND psi.status = "available") AS available_stock FROM products pr INNER JOIN categories cat ON pr.category_id = cat.id WHERE pr.status = ?';
+            $productsQuery = 'SELECT pr.*, cat.name AS category_name,
+                (SELECT COUNT(*) FROM product_stock_items psi WHERE psi.product_id = pr.id AND psi.status = \'available\') AS available_stock,
+                (SELECT COUNT(*) FROM product_stock_items psi_all WHERE psi_all.product_id = pr.id) AS total_stock_items
+                FROM products pr INNER JOIN categories cat ON pr.category_id = cat.id WHERE pr.status = ?';
             $productParams = ['active'];
 
             if ($searchTerm !== '') {
@@ -322,16 +332,32 @@ $renderProductCard = function (array $product, $highlight = false) use ($categor
     $shortDescription = Helpers::truncate($rawDescription, 140);
     $skuValue = (isset($product['sku']) && $product['sku'] !== '') ? $product['sku'] : null;
     $automaticDelivery = isset($product['automatic_delivery']) ? (int)$product['automatic_delivery'] === 1 : false;
-    $isStockBased = !$automaticDelivery;
+    $totalStockItems = isset($product['total_stock_items']) ? (int)$product['total_stock_items'] : 0;
+    $usesStock = !$automaticDelivery || $totalStockItems > 0;
     $availableStock = isset($product['available_stock']) ? (int)$product['available_stock'] : 0;
     $stockBadgeClass = 'bg-info text-dark';
     $stockLabel = 'Teslimat durumunu yöneticinizden öğrenin';
+    $stockDetail = '';
     $restockHint = '';
 
-    if ($automaticDelivery && !$isStockBased) {
+    if ($automaticDelivery) {
         $stockBadgeClass = 'bg-primary';
         $stockLabel = 'Otomatik teslimat';
-    } elseif ($isStockBased) {
+        if ($usesStock) {
+            if ($availableStock > 0) {
+                $stockDetail = sprintf('Stok: %d adet', $availableStock);
+                if ($availableStock <= 3) {
+                    $restockHint = 'Stok seviyesi kritik, yöneticinizden yenileme talep edin.';
+                }
+            } else {
+                $stockBadgeClass = 'bg-danger';
+                $stockDetail = 'Stok tükendi';
+                $restockHint = 'Bu ürün için stok bildirimi ayarlayabilirsiniz.';
+            }
+        } else {
+            $stockDetail = 'Sınırsız teslimat';
+        }
+    } elseif ($usesStock) {
         if ($availableStock > 0) {
             $stockBadgeClass = 'bg-success';
             $stockLabel = sprintf('Stokta %d adet', $availableStock);
@@ -347,62 +373,81 @@ $renderProductCard = function (array $product, $highlight = false) use ($categor
 
     $isFavorited = in_array($productId, $favoriteProductIds, true) || $highlight;
     $isWatching = in_array($productId, $watchingProductIds, true);
-    $buttonDisabled = $isStockBased && $availableStock <= 0;
+    $buttonDisabled = $usesStock && $availableStock <= 0;
 
     $cardClasses = 'product-card';
     if ($highlight) {
         $cardClasses .= ' product-card--favorite';
     }
 
+    $imagePath = isset($product['image']) ? trim((string)$product['image']) : '';
+    $imageUrl = $imagePath !== '' ? ($imagePath[0] === '/' ? $imagePath : '/' . ltrim($imagePath, '/')) : '/assets/no-image.svg';
+    $durationLabel = $automaticDelivery ? 'Anında Teslim' : 'Stoktan Teslim';
+    $supplierLabel = isset($product['provider_name']) && $product['provider_name'] !== '' ? (string)$product['provider_name'] : 'Panel';
+    $categorySupplierLabel = $categoryTrail . ' / ' . $supplierLabel;
+    $hasUnlimitedDelivery = $automaticDelivery && !$usesStock;
+    $automaticBadgeClass = $automaticDelivery ? 'bg-primary text-white' : 'bg-secondary text-white';
+    $unlimitedBadgeClass = $hasUnlimitedDelivery ? 'bg-success text-white' : 'bg-secondary text-white';
+
     ob_start();
     ?>
     <div class="<?= $cardClasses ?>" data-product-card="<?= $productId ?>"<?= $highlight ? ' data-favorite-card="1"' : '' ?>>
-        <div class="product-card__header">
-            <div>
-                <h3 class="product-card__title"><?= Helpers::sanitize($productName) ?></h3>
-                <div class="product-card__category"><?= Helpers::sanitize($categoryTrail) ?></div>
-            </div>
-            <div class="product-card__price"><?= $productPriceHtml ?></div>
+        <div class="product-card__media">
+            <img src="<?= Helpers::sanitize($imageUrl) ?>" alt="<?= Helpers::sanitize($productName) ?>">
         </div>
-        <?php if ($skuValue): ?>
-            <div class="product-card__sku">SKU: <?= Helpers::sanitize($skuValue) ?></div>
-        <?php endif; ?>
-        <div class="product-card__stock">
-            <span class="badge <?= htmlspecialchars($stockBadgeClass, ENT_QUOTES, 'UTF-8') ?>"><?= Helpers::sanitize($stockLabel) ?></span>
-        </div>
-        <p class="product-card__description"><?= Helpers::sanitize($shortDescription) ?></p>
-        <?php if ($restockHint !== ''): ?>
-            <div class="product-card__hint text-muted small mb-2">
-                <i class="bi bi-lightbulb me-1"></i><?= Helpers::sanitize($restockHint) ?>
+        <div class="product-card__body">
+            <div class="product-card__top">
+                <h3 class="product-card__title"><?= Helpers::sanitize($productName) ?><span class="product-card__duration"> – <?= Helpers::sanitize($durationLabel) ?></span></h3>
+                <div class="product-card__price"><?= $productPriceHtml ?></div>
             </div>
-        <?php endif; ?>
-        <div class="product-card__actions">
-            <button type="button"
-                    class="product-card__button<?= $buttonDisabled ? ' is-disabled' : '' ?>"
-                    data-bs-toggle="modal"
-                    data-bs-target="#orderModal"
-                    data-product-id="<?= $productId ?>"
-                    data-product-name="<?= Helpers::sanitize($productName) ?>"
-                    data-product-price-html="<?= htmlspecialchars($productPriceHtml, ENT_QUOTES, 'UTF-8') ?>"
-                    data-product-base-amount="<?= Helpers::sanitize(number_format($productBaseAmount, 6, '.', '')) ?>"
-                    data-product-base-currency="<?= Helpers::sanitize($productBaseCurrency) ?>"
-                    data-product-sku="<?= Helpers::sanitize($skuValue ?: '-') ?>"
-                    data-product-category="<?= Helpers::sanitize($categoryTrail) ?>"
-                    <?= $buttonDisabled ? 'disabled aria-disabled="true" title="Stok tükendi"' : '' ?>>
-                Sipariş ver
-            </button>
-            <button type="button"
-                    class="btn btn-outline-secondary btn-sm ms-2 js-favorite-toggle<?= $isFavorited ? ' active' : '' ?>"
-                    data-product-id="<?= $productId ?>"
-                    title="<?= $isFavorited ? 'Favorilerden çıkar' : 'Favorilere ekle' ?>">
-                <i class="bi <?= $isFavorited ? 'bi-heart-fill text-danger' : 'bi-heart' ?>"></i>
-            </button>
-            <button type="button"
-                    class="btn btn-outline-warning btn-sm ms-2 js-watch-toggle<?= $isWatching ? ' active' : '' ?>"
-                    data-product-id="<?= $productId ?>"
-                    title="Stok bildirimi">
-                <i class="bi <?= $isWatching ? 'bi-bell-fill' : 'bi-bell' ?>"></i>
-            </button>
+            <div class="product-card__meta-line"><?= Helpers::sanitize($categorySupplierLabel) ?></div>
+            <?php if ($skuValue): ?>
+                <div class="product-card__sku">SKU: <?= Helpers::sanitize($skuValue) ?></div>
+            <?php endif; ?>
+            <div class="product-card__badges">
+                <span class="badge <?= htmlspecialchars($automaticBadgeClass, ENT_QUOTES, 'UTF-8') ?>"><?= Helpers::sanitize($automaticDelivery ? 'Otomatik Teslimat' : 'Manuel Teslimat') ?></span>
+                <span class="badge <?= htmlspecialchars($unlimitedBadgeClass, ENT_QUOTES, 'UTF-8') ?>"><?= Helpers::sanitize($hasUnlimitedDelivery ? 'Sınırsız Teslimat' : 'Stok Takipli') ?></span>
+            </div>
+            <div class="product-card__stock">
+                <span class="badge <?= htmlspecialchars($stockBadgeClass, ENT_QUOTES, 'UTF-8') ?>"><?= Helpers::sanitize($stockLabel) ?></span>
+                <?php if ($stockDetail !== ''): ?>
+                    <div class="product-card__stock-detail"><?= Helpers::sanitize($stockDetail) ?></div>
+                <?php endif; ?>
+            </div>
+            <p class="product-card__description"><?= Helpers::sanitize($shortDescription) ?></p>
+            <?php if ($restockHint !== ''): ?>
+                <div class="product-card__hint">
+                    <i class="bi bi-lightbulb me-1"></i><?= Helpers::sanitize($restockHint) ?>
+                </div>
+            <?php endif; ?>
+            <div class="product-card__actions">
+                <button type="button"
+                        class="product-card__button<?= $buttonDisabled ? ' is-disabled' : '' ?>"
+                        data-bs-toggle="modal"
+                        data-bs-target="#orderModal"
+                        data-product-id="<?= $productId ?>"
+                        data-product-name="<?= Helpers::sanitize($productName) ?>"
+                        data-product-price-html="<?= htmlspecialchars($productPriceHtml, ENT_QUOTES, 'UTF-8') ?>"
+                        data-product-base-amount="<?= Helpers::sanitize(number_format($productBaseAmount, 6, '.', '')) ?>"
+                        data-product-base-currency="<?= Helpers::sanitize($productBaseCurrency) ?>"
+                        data-product-sku="<?= Helpers::sanitize($skuValue ?: '-') ?>"
+                        data-product-category="<?= Helpers::sanitize($categoryTrail) ?>"
+                        <?= $buttonDisabled ? 'disabled aria-disabled="true" title="Stok tükendi"' : '' ?>>
+                    Sipariş ver
+                </button>
+                <button type="button"
+                        class="btn btn-outline-secondary btn-sm js-favorite-toggle<?= $isFavorited ? ' active' : '' ?>"
+                        data-product-id="<?= $productId ?>"
+                        title="<?= $isFavorited ? 'Favorilerden çıkar' : 'Favorilere ekle' ?>">
+                    <i class="bi <?= $isFavorited ? 'bi-heart-fill text-danger' : 'bi-heart' ?>"></i>
+                </button>
+                <button type="button"
+                        class="btn btn-outline-warning btn-sm js-watch-toggle<?= $isWatching ? ' active' : '' ?>"
+                        data-product-id="<?= $productId ?>"
+                        title="Stok bildirimi">
+                    <i class="bi <?= $isWatching ? 'bi-bell-fill' : 'bi-bell' ?>"></i>
+                </button>
+            </div>
         </div>
     </div>
     <?php
@@ -564,9 +609,11 @@ include __DIR__ . '/templates/header.php';
             <div class="catalog-subheader">Ürünler</div>
 
             <?php if ($products): ?>
-                <div class="catalog-products">
+                <div class="catalog-products row g-4">
                     <?php foreach ($products as $product): ?>
-                        <?= $renderProductCard($product) ?>
+                        <div class="col-12 col-sm-6 col-md-4 col-lg-3 d-flex">
+                            <?= $renderProductCard($product) ?>
+                        </div>
                     <?php endforeach; ?>
                 </div>
             <?php else: ?>

--- a/schema.sql
+++ b/schema.sql
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS products (
     name VARCHAR(150) NOT NULL,
     sku VARCHAR(150) NULL,
     description TEXT NULL,
+    image VARCHAR(255) NULL,
     cost_price_try DECIMAL(12,2) NULL,
     price DECIMAL(12,2) NOT NULL DEFAULT 0,
     status ENUM('active','inactive') NOT NULL DEFAULT 'active',
@@ -100,6 +101,62 @@ CREATE TABLE IF NOT EXISTS products (
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (category_id) REFERENCES categories(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS provider_sources (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    base_url VARCHAR(255) NOT NULL,
+    consumer_key VARCHAR(191) NULL,
+    consumer_secret VARCHAR(191) NULL,
+    webhook_secret VARCHAR(191) NULL,
+    status ENUM('active','inactive') NOT NULL DEFAULT 'inactive',
+    last_synced_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_provider_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS provider_remote_categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    provider_id INT NOT NULL,
+    remote_id BIGINT NOT NULL,
+    parent_remote_id BIGINT NULL,
+    name VARCHAR(191) NOT NULL,
+    slug VARCHAR(191) NULL,
+    mapped_category_id INT NULL,
+    last_synced_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_provider_remote_category (provider_id, remote_id),
+    INDEX idx_provider_category_lookup (provider_id, mapped_category_id),
+    FOREIGN KEY (provider_id) REFERENCES provider_sources(id) ON DELETE CASCADE,
+    FOREIGN KEY (mapped_category_id) REFERENCES categories(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS provider_remote_products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    provider_id INT NOT NULL,
+    remote_id BIGINT NOT NULL,
+    name VARCHAR(191) NOT NULL,
+    slug VARCHAR(191) NULL,
+    price DECIMAL(12,2) NULL,
+    currency VARCHAR(10) NULL,
+    status VARCHAR(50) NULL,
+    remote_category_id BIGINT NULL,
+    remote_category_name VARCHAR(191) NULL,
+    stock_quantity INT NULL,
+    stock_status VARCHAR(50) NULL,
+    imported_product_id INT NULL,
+    announcement_id INT NULL,
+    last_synced_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_provider_remote_product (provider_id, remote_id),
+    INDEX idx_provider_remote_category (provider_id, remote_category_id),
+    FOREIGN KEY (provider_id) REFERENCES provider_sources(id) ON DELETE CASCADE,
+    FOREIGN KEY (imported_product_id) REFERENCES products(id) ON DELETE SET NULL,
+    FOREIGN KEY (announcement_id) REFERENCES announcements(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS reseller_favorites (
@@ -241,6 +298,13 @@ CREATE TABLE IF NOT EXISTS system_settings (
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO system_settings (setting_key, setting_value, created_at) VALUES
+    ('ai_image_enabled', '0', NOW()),
+    ('ai_api_key', NULL, NOW()),
+    ('ai_prompt', NULL, NOW()),
+    ('ai_image_template', NULL, NOW())
+    ON DUPLICATE KEY UPDATE setting_value = setting_value;
 
 CREATE TABLE IF NOT EXISTS admin_activity_logs (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/src/Migrations/Schema.php
+++ b/src/Migrations/Schema.php
@@ -21,6 +21,9 @@ final class Schema
         self::ensureLanguageTranslationsTable($pdo);
         self::ensureCategoriesTable($pdo);
         self::ensureProductsTable($pdo);
+        self::ensureProviderSourcesTable($pdo);
+        self::ensureProviderRemoteCategoriesTable($pdo);
+        self::ensureProviderRemoteProductsTable($pdo);
         self::ensureProductStockTable($pdo);
         self::ensureProductOrdersTable($pdo);
         self::ensureResellerFavoritesTable($pdo);
@@ -125,6 +128,7 @@ final class Schema
             name VARCHAR(150) NOT NULL,
             sku VARCHAR(150) NULL,
             description MEDIUMTEXT NULL,
+            image VARCHAR(255) NULL,
             cost_price_try DECIMAL(12,2) NULL,
             price DECIMAL(12,2) NOT NULL DEFAULT 0,
             status ENUM('active','inactive') NOT NULL DEFAULT 'active',
@@ -135,6 +139,87 @@ final class Schema
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
         self::ensureColumn($pdo, 'products', 'automatic_delivery', "TINYINT(1) NOT NULL DEFAULT 1");
+        self::ensureColumn($pdo, 'products', 'image', 'VARCHAR(255) NULL');
+    }
+
+    private static function ensureProviderSourcesTable(PDO $pdo): void
+    {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS provider_sources (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(150) NOT NULL,
+            base_url VARCHAR(255) NOT NULL,
+            consumer_key VARCHAR(191) NULL,
+            consumer_secret VARCHAR(191) NULL,
+            webhook_secret VARCHAR(191) NULL,
+            status ENUM('active','inactive') NOT NULL DEFAULT 'inactive',
+            last_synced_at DATETIME NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uniq_provider_name (name)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        self::ensureColumn($pdo, 'provider_sources', 'webhook_secret', 'VARCHAR(191) NULL');
+        self::ensureColumn($pdo, 'provider_sources', 'last_synced_at', 'DATETIME NULL');
+    }
+
+    private static function ensureProviderRemoteCategoriesTable(PDO $pdo): void
+    {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS provider_remote_categories (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            provider_id INT NOT NULL,
+            remote_id BIGINT NOT NULL,
+            parent_remote_id BIGINT NULL,
+            name VARCHAR(191) NOT NULL,
+            slug VARCHAR(191) NULL,
+            mapped_category_id INT NULL,
+            last_synced_at DATETIME NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uniq_provider_remote_category (provider_id, remote_id),
+            INDEX idx_provider_category_lookup (provider_id, mapped_category_id),
+            CONSTRAINT fk_provider_category_source FOREIGN KEY (provider_id) REFERENCES provider_sources(id) ON DELETE CASCADE,
+            CONSTRAINT fk_provider_category_mapping FOREIGN KEY (mapped_category_id) REFERENCES categories(id) ON DELETE SET NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        self::ensureColumn($pdo, 'provider_remote_categories', 'last_synced_at', 'DATETIME NULL');
+        self::ensureColumn($pdo, 'provider_remote_categories', 'mapped_category_id', 'INT NULL');
+        self::addIndex($pdo, 'provider_remote_categories', 'idx_provider_category_lookup', 'ADD INDEX idx_provider_category_lookup (provider_id, mapped_category_id)');
+    }
+
+    private static function ensureProviderRemoteProductsTable(PDO $pdo): void
+    {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS provider_remote_products (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            provider_id INT NOT NULL,
+            remote_id BIGINT NOT NULL,
+            name VARCHAR(191) NOT NULL,
+            slug VARCHAR(191) NULL,
+            price DECIMAL(12,2) NULL,
+            currency VARCHAR(10) NULL,
+            status VARCHAR(50) NULL,
+            remote_category_id BIGINT NULL,
+            remote_category_name VARCHAR(191) NULL,
+            stock_quantity INT NULL,
+            stock_status VARCHAR(50) NULL,
+            imported_product_id INT NULL,
+            announcement_id INT NULL,
+            last_synced_at DATETIME NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uniq_provider_remote_product (provider_id, remote_id),
+            INDEX idx_provider_remote_category (provider_id, remote_category_id),
+            CONSTRAINT fk_provider_product_source FOREIGN KEY (provider_id) REFERENCES provider_sources(id) ON DELETE CASCADE,
+            CONSTRAINT fk_provider_product_local FOREIGN KEY (imported_product_id) REFERENCES products(id) ON DELETE SET NULL,
+            CONSTRAINT fk_provider_product_announcement FOREIGN KEY (announcement_id) REFERENCES announcements(id) ON DELETE SET NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        self::ensureColumn($pdo, 'provider_remote_products', 'currency', 'VARCHAR(10) NULL');
+        self::ensureColumn($pdo, 'provider_remote_products', 'remote_category_name', 'VARCHAR(191) NULL');
+        self::ensureColumn($pdo, 'provider_remote_products', 'stock_quantity', 'INT NULL');
+        self::ensureColumn($pdo, 'provider_remote_products', 'stock_status', 'VARCHAR(50) NULL');
+        self::ensureColumn($pdo, 'provider_remote_products', 'announcement_id', 'INT NULL');
+        self::ensureColumn($pdo, 'provider_remote_products', 'last_synced_at', 'DATETIME NULL');
+        self::addIndex($pdo, 'provider_remote_products', 'idx_provider_remote_category', 'ADD INDEX idx_provider_remote_category (provider_id, remote_category_id)');
     }
 
     private static function ensureProductStockTable(PDO $pdo): void

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -25,63 +25,70 @@ $pageInlineScripts = isset($GLOBALS['pageInlineScripts']) && is_array($GLOBALS['
     document.addEventListener('DOMContentLoaded', function () {
         var app = window.App = window.App || {};
 
-        var sidebar = document.getElementById('appSidebar');
-        if (sidebar) {
-            var body = document.body;
-            var toggles = document.querySelectorAll('[data-sidebar-toggle]');
-            var closers = document.querySelectorAll('[data-sidebar-close]');
-            var sidebarLinks = sidebar.querySelectorAll('a');
+        var tables = Array.prototype.slice.call(document.querySelectorAll('table'));
+        tables.forEach(function (table) {
+            if (!table || table.closest('.table-responsive')) {
+                return;
+            }
+            var wrapper = document.createElement('div');
+            wrapper.className = 'table-responsive';
+            table.parentNode.insertBefore(wrapper, table);
+            wrapper.appendChild(table);
+        });
 
-            var closeSidebar = function () {
-                if (!body.classList.contains('sidebar-open')) {
-                    return;
-                }
-                body.classList.remove('sidebar-open');
-                toggles.forEach(function (toggle) {
-                    toggle.setAttribute('aria-expanded', 'false');
-                });
-            };
+        if (window.bootstrap) {
+            var navbarElement = document.getElementById('appNavbar');
+            if (navbarElement) {
+                var dropdownToggles = Array.prototype.slice.call(navbarElement.querySelectorAll('.dropdown-toggle'));
+                dropdownToggles.forEach(function (toggle) {
+                    toggle.addEventListener('keydown', function (event) {
+                        var key = event.key || event.code;
+                        if (key === ' ' || key === 'Spacebar') {
+                            key = 'Space';
+                        }
+                        if (key === 'Enter' || key === 'Space' || key === 'ArrowDown') {
+                            event.preventDefault();
+                            var dropdown = bootstrap.Dropdown.getOrCreateInstance(toggle, { autoClose: 'outside' });
+                            dropdown.show();
+                            var menu = toggle.nextElementSibling;
+                            if (menu) {
+                                var firstItem = menu.querySelector('.dropdown-item');
+                                if (firstItem) {
+                                    setTimeout(function () {
+                                        firstItem.focus();
+                                    }, 10);
+                                }
+                            }
+                        } else if (key === 'ArrowUp') {
+                            event.preventDefault();
+                            var dropdownUp = bootstrap.Dropdown.getOrCreateInstance(toggle, { autoClose: 'outside' });
+                            dropdownUp.show();
+                            var menuUp = toggle.nextElementSibling;
+                            if (menuUp) {
+                                var items = menuUp.querySelectorAll('.dropdown-item');
+                                if (items.length) {
+                                    setTimeout(function () {
+                                        items[items.length - 1].focus();
+                                    }, 10);
+                                }
+                            }
+                        }
+                    });
 
-            var openSidebar = function (trigger) {
-                body.classList.add('sidebar-open');
-                toggles.forEach(function (toggle) {
-                    toggle.setAttribute('aria-expanded', toggle === trigger ? 'true' : 'false');
-                });
-            };
-
-            toggles.forEach(function (toggle) {
-                toggle.addEventListener('click', function () {
-                    if (body.classList.contains('sidebar-open')) {
-                        closeSidebar();
-                    } else {
-                        openSidebar(toggle);
+                    var menuElement = toggle.nextElementSibling;
+                    if (menuElement && !menuElement.hasAttribute('data-app-dropdown-keyboard')) {
+                        menuElement.setAttribute('data-app-dropdown-keyboard', 'true');
+                        menuElement.addEventListener('keydown', function (event) {
+                            if (event.key === 'Escape' || event.key === 'Esc') {
+                                event.preventDefault();
+                                var dropdownInstance = bootstrap.Dropdown.getOrCreateInstance(toggle, { autoClose: 'outside' });
+                                dropdownInstance.hide();
+                                toggle.focus();
+                            }
+                        });
                     }
                 });
-            });
-
-            closers.forEach(function (closer) {
-                closer.addEventListener('click', closeSidebar);
-            });
-
-            sidebarLinks.forEach(function (link) {
-                link.addEventListener('click', function () {
-                    if (window.innerWidth < 992) {
-                        closeSidebar();
-                    }
-                });
-            });
-
-            document.addEventListener('keyup', function (event) {
-                if (event.key === 'Escape') {
-                    closeSidebar();
-                }
-            });
-
-            window.addEventListener('resize', function () {
-                if (window.innerWidth >= 992) {
-                    closeSidebar();
-                }
-            });
+            }
         }
 
         function toPairs(dictionary) {

--- a/templates/header.php
+++ b/templates/header.php
@@ -8,6 +8,7 @@ use App\FeatureToggle;
 use App\ResellerPolicy;
 use App\Services\LanguageService;
 use App\Services\AnnouncementService;
+use App\Settings;
 
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_start();
@@ -36,6 +37,20 @@ $siteName = Helpers::siteName();
 $siteTagline = Helpers::siteTagline();
 $metaDescription = Helpers::seoDescription();
 $metaKeywords = Helpers::seoKeywords();
+
+$siteLogoSetting = Settings::get('site_logo');
+$siteLogoUrl = '';
+if ($siteLogoSetting !== null && trim((string) $siteLogoSetting) !== '') {
+    $siteLogoCandidate = trim((string) $siteLogoSetting);
+    if (preg_match('/^https?:\/\//i', $siteLogoCandidate)) {
+        $siteLogoUrl = $siteLogoCandidate;
+    } else {
+        $siteLogoUrl = '/' . ltrim($siteLogoCandidate, '/');
+    }
+}
+if ($siteLogoUrl === '') {
+    $siteLogoUrl = '/assets/logo-default.svg';
+}
 
 $activeLocale = Lang::locale();
 $defaultLocale = Lang::defaultLocale();
@@ -89,8 +104,6 @@ foreach ($languageOptions as $option) {
 }
 
 $showLanguageSwitch = count($languageOptions) > 1;
-$hasTopbarActions = $showLanguageSwitch;
-
 $appCsrfToken = Helpers::csrfToken();
 $activeTranslations = class_exists(LanguageService::class) ? LanguageService::catalog($activeLocale) : array();
 $fallbackTranslations = class_exists(LanguageService::class) ? LanguageService::catalog($defaultLocale) : array();
@@ -133,6 +146,7 @@ if ($user) {
                     array('label' => 'Raporlar', 'href' => '/admin/reports.php', 'pattern' => '/admin/reports.php', 'icon' => 'bi-graph-up', 'roles' => array('super_admin', 'admin', 'finance')),
                     array('label' => 'Paketler', 'href' => '/admin/packages.php', 'pattern' => '/admin/packages.php', 'icon' => 'bi-box-seam', 'roles' => array('super_admin', 'admin')),
                     array('label' => 'Bayiler', 'href' => '/admin/users.php', 'pattern' => '/admin/users.php', 'icon' => 'bi-people', 'roles' => array('super_admin', 'admin')),
+                    array('label' => 'Aktivite Kayıtları', 'href' => '/admin/activity-logs.php', 'pattern' => '/admin/activity-logs.php', 'icon' => 'bi-clipboard-data', 'roles' => array('super_admin', 'admin')),
                 ),
             ),
             array(
@@ -147,6 +161,7 @@ if ($user) {
                 'items' => array(
                     array('label' => 'Ürünler', 'href' => '/admin/products.php', 'pattern' => '/admin/products.php', 'icon' => 'bi-box', 'roles' => array('super_admin', 'admin', 'content')),
                     array('label' => 'Stok Yönetimi', 'href' => '/admin/product-stock.php', 'pattern' => '/admin/product-stock.php', 'icon' => 'bi-archive', 'roles' => array('super_admin', 'admin', 'content')),
+                    array('label' => 'Sağlayıcılar', 'href' => '/admin/providers.php', 'pattern' => '/admin/providers.php', 'icon' => 'bi-plug', 'roles' => array('super_admin', 'admin')),
                     array('label' => 'Kategoriler', 'href' => '/admin/categories.php', 'pattern' => '/admin/categories.php', 'icon' => 'bi-diagram-3', 'roles' => array('super_admin', 'admin', 'content')),
                 ),
             ),
@@ -179,12 +194,6 @@ if ($user) {
                     array('label' => 'Ödeme Methodları', 'href' => '/admin/settings-payments.php', 'pattern' => '/admin/settings-payments.php', 'icon' => 'bi-credit-card', 'roles' => array('super_admin', 'admin', 'finance')),
                     array('label' => 'Dil Yönetimi', 'href' => '/admin/languages.php', 'pattern' => '/admin/languages.php', 'icon' => 'bi-translate', 'roles' => array('super_admin', 'admin')),
                     array('label' => 'Telegram Ayarları', 'href' => '/admin/settings-telegram.php', 'pattern' => '/admin/settings-telegram.php', 'icon' => 'bi-telegram', 'roles' => array('super_admin', 'admin')),
-                ),
-            ),
-            array(
-                'heading' => 'Denetim',
-                'items' => array(
-                    array('label' => 'Aktivite Kayıtları', 'href' => '/admin/activity-logs.php', 'pattern' => '/admin/activity-logs.php', 'icon' => 'bi-clipboard-data', 'roles' => array('super_admin', 'admin')),
                 ),
             ),
         );
@@ -243,13 +252,50 @@ if ($user && !$isAdminRole) {
     $activeAnnouncements = AnnouncementService::activeForUser($user, 4, $dismissedAnnouncementIds);
 }
 
-$nameSource = $user['name'] ?? ($user['email'] ?? 'U');
+$userDisplayName = '';
+if ($user) {
+    $userDisplayName = isset($user['name']) && $user['name'] !== ''
+        ? (string) $user['name']
+        : (isset($user['email']) ? (string) $user['email'] : '');
+}
+
+$nameSource = $userDisplayName !== '' ? $userDisplayName : ($user['email'] ?? 'U');
 if (function_exists('mb_substr')) {
     $avatarInitial = mb_strtoupper(mb_substr($nameSource, 0, 1, 'UTF-8'), 'UTF-8');
 } else {
     $avatarInitial = strtoupper(substr($nameSource, 0, 1));
 }
 $userRoleLabel = $user ? Auth::roleLabel($user['role']) : '';
+
+$userAvatarUrl = '';
+if ($user) {
+    $avatarKeys = array('avatar_url', 'avatar', 'profile_photo', 'profile_photo_url');
+    foreach ($avatarKeys as $avatarKey) {
+        if (!empty($user[$avatarKey])) {
+            $candidate = (string) $user[$avatarKey];
+            if (preg_match('/^https?:\/\//i', $candidate)) {
+                $userAvatarUrl = $candidate;
+            } else {
+                $userAvatarUrl = '/' . ltrim($candidate, '/');
+            }
+            break;
+        }
+    }
+}
+
+$userBalanceValue = isset($user['balance']) ? (float) $user['balance'] : 0.0;
+$userBalanceHtml = Helpers::formatCurrencyHtml($userBalanceValue);
+$showBalanceInfo = $user && ($isAdminRole || Helpers::featureEnabled('balance'));
+
+$resellerFlatItems = array();
+if ($user && !$isAdminRole) {
+    foreach ($menuSections as $section) {
+        $sectionItems = $section['items'] ?? array();
+        foreach ($sectionItems as $sectionItem) {
+            $resellerFlatItems[] = $sectionItem;
+        }
+    }
+}
 ?>
 <!DOCTYPE html>
 <html lang="<?= Lang::htmlLocale() ?>">
@@ -278,85 +324,156 @@ $userRoleLabel = $user ? Auth::roleLabel($user['role']) : '';
 <body>
 <div class="app-shell">
     <?php if ($user): ?>
-        <aside class="app-sidebar" id="appSidebar">
-            <div class="sidebar-brand">
-                <a href="<?= $isAdminArea ? '/admin/dashboard.php' : '/dashboard.php' ?>"><?= Helpers::sanitize($siteName) ?></a>
-                <?php if ($siteTagline): ?>
-                    <div class="sidebar-brand-tagline text-muted small"><?= Helpers::sanitize($siteTagline) ?></div>
-                <?php endif; ?>
-            </div>
-            <div class="sidebar-user d-flex align-items-center gap-3">
-                <span class="avatar-circle avatar-circle--sidebar fw-semibold flex-shrink-0"><?= Helpers::sanitize($avatarInitial) ?></span>
-                <div class="flex-grow-1">
-                    <div class="sidebar-user-name fw-semibold mb-1"><?= Helpers::sanitize($user['name']) ?></div>
-                    <div class="sidebar-user-role text-uppercase small mb-2"><?= Helpers::sanitize($userRoleLabel) ?></div>
-                    <?php if (Helpers::featureEnabled('balance')): ?>
-                        <div class="sidebar-user-balance small text-white-75">
-                            <?= Helpers::sanitize('Bakiye') ?>:
-                            <strong><?= Helpers::formatCurrencyHtml((float) $user['balance']) ?></strong>
-                        </div>
+        <header class="app-navbar navbar navbar-expand-lg navbar-dark" id="appNavbar" role="banner">
+            <div class="container-fluid app-navbar-container">
+                <a class="navbar-brand d-flex align-items-center" href="<?= $isAdminArea ? '/admin/dashboard.php' : '/dashboard.php' ?>">
+                    <?php if ($siteLogoUrl): ?>
+                        <img src="<?= Helpers::sanitize($siteLogoUrl) ?>" alt="<?= Helpers::sanitize($siteName) ?>" class="navbar-brand-logo">
                     <?php endif; ?>
+                    <span class="visually-hidden"><?= Helpers::sanitize($siteName) ?></span>
+                </a>
+                <button class="navbar-toggler d-lg-none ms-auto" type="button" data-bs-toggle="collapse" data-bs-target="#appNavbarNav" aria-controls="appNavbarNav" aria-expanded="false" aria-label="<?= Helpers::sanitize('Menüyü Aç') ?>">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="collapse navbar-collapse" id="appNavbarNav" role="navigation" aria-label="<?= Helpers::sanitize('Ana menü') ?>">
+                    <div class="navbar-collapse-inner d-flex flex-column flex-lg-row align-items-lg-center w-100 gap-4">
+                        <div class="navbar-center flex-grow-1 order-1 order-lg-1 w-100">
+                        <?php if ($menuSections): ?>
+                            <div class="navbar-menu-scroll" tabindex="0">
+                                <ul class="navbar-nav ms-lg-3 align-items-lg-center justify-content-lg-start" role="menubar" aria-label="<?= Helpers::sanitize('Birincil menü') ?>">
+                                        <?php if ($isAdminRole): ?>
+                                            <?php foreach ($menuSections as $section): ?>
+                                                <?php
+                                                $sectionItems = $section['items'] ?? array();
+                                                $hasMultiple = count($sectionItems) > 1;
+                                                $sectionActive = false;
+                                                foreach ($sectionItems as $sectionItem) {
+                                                    if (Helpers::isActive($sectionItem['pattern'])) {
+                                                        $sectionActive = true;
+                                                        break;
+                                                    }
+                                                }
+                                                ?>
+                                                <?php if ($hasMultiple): ?>
+                                                    <li class="nav-item dropdown" role="none">
+                                                        <a class="nav-link dropdown-toggle<?= $sectionActive ? ' active' : '' ?>" href="#" id="dropdown-<?= md5($section['heading']) ?>" role="menuitem" data-bs-toggle="dropdown" data-bs-display="static" aria-haspopup="true" aria-expanded="false">
+                                                            <span class="nav-link-text"><?= Helpers::sanitize($section['heading']) ?></span>
+                                                        </a>
+                                                        <ul class="dropdown-menu" aria-labelledby="dropdown-<?= md5($section['heading']) ?>" role="menu" aria-label="<?= Helpers::sanitize($section['heading']) ?>">
+                                                            <?php foreach ($sectionItems as $navItem): ?>
+                                                                <?php $itemActive = Helpers::isActive($navItem['pattern']); ?>
+                                                                <li role="none">
+                                                                    <a class="dropdown-item d-flex align-items-center gap-2<?= $itemActive ? ' active' : '' ?>" href="<?= $navItem['href'] ?>" role="menuitem"<?= $itemActive ? ' aria-current="page"' : '' ?>>
+                                                                        <?php if (!empty($navItem['icon'])): ?>
+                                                                            <i class="<?= Helpers::sanitize($navItem['icon']) ?>"></i>
+                                                                        <?php endif; ?>
+                                                                        <span><?= Helpers::sanitize($navItem['label']) ?></span>
+                                                                        <?php if (!empty($navItem['badge']) && (int) $navItem['badge'] > 0): ?>
+                                                                            <span class="menu-badge ms-auto"><?= (int) $navItem['badge'] ?></span>
+                                                                        <?php endif; ?>
+                                                                    </a>
+                                                                </li>
+                                                            <?php endforeach; ?>
+                                                        </ul>
+                                                    </li>
+                                                <?php else: ?>
+                                                    <?php $navItem = reset($sectionItems); ?>
+                                                    <?php if ($navItem): ?>
+                                                        <?php $itemActive = Helpers::isActive($navItem['pattern']); ?>
+                                                        <li class="nav-item" role="none">
+                                                            <a class="nav-link d-flex align-items-center gap-2<?= $itemActive ? ' active' : '' ?>" href="<?= $navItem['href'] ?>" role="menuitem"<?= $itemActive ? ' aria-current="page"' : '' ?>>
+                                                                <?php if (!empty($navItem['icon'])): ?>
+                                                                    <i class="<?= Helpers::sanitize($navItem['icon']) ?>"></i>
+                                                                <?php endif; ?>
+                                                                <span class="nav-link-text"><?= Helpers::sanitize($navItem['label']) ?></span>
+                                                                <?php if (!empty($navItem['badge']) && (int) $navItem['badge'] > 0): ?>
+                                                                    <span class="menu-badge ms-lg-1"><?= (int) $navItem['badge'] ?></span>
+                                                                <?php endif; ?>
+                                                            </a>
+                                                        </li>
+                                                    <?php endif; ?>
+                                                <?php endif; ?>
+                                            <?php endforeach; ?>
+                                        <?php else: ?>
+                                            <?php foreach ($resellerFlatItems as $navItem): ?>
+                                                <?php $itemActive = Helpers::isActive($navItem['pattern']); ?>
+                                                <li class="nav-item" role="none">
+                                                    <a class="nav-link d-flex align-items-center gap-2<?= $itemActive ? ' active' : '' ?>" href="<?= $navItem['href'] ?>" role="menuitem"<?= $itemActive ? ' aria-current="page"' : '' ?>>
+                                                        <?php if (!empty($navItem['icon'])): ?>
+                                                            <i class="<?= Helpers::sanitize($navItem['icon']) ?>"></i>
+                                                        <?php endif; ?>
+                                                        <span class="nav-link-text"><?= Helpers::sanitize($navItem['label']) ?></span>
+                                                        <?php if (!empty($navItem['badge']) && (int) $navItem['badge'] > 0): ?>
+                                                            <span class="menu-badge ms-lg-1"><?= (int) $navItem['badge'] ?></span>
+                                                        <?php endif; ?>
+                                                    </a>
+                                                </li>
+                                            <?php endforeach; ?>
+                                        <?php endif; ?>
+                                    </ul>
+                                </div>
+                            <?php endif; ?>
+                        </div>
+                        <div class="navbar-right order-2 order-lg-2 d-flex flex-column flex-lg-row align-items-stretch align-items-lg-center gap-3 ms-lg-auto ps-lg-4">
+                            <?php if ($showLanguageSwitch): ?>
+                                <div class="nav-language">
+                                    <label class="form-label text-white-50 mb-1" for="appLanguageSelect"><?= Helpers::sanitize('Dil') ?></label>
+                                    <select class="form-select form-select-sm" id="appLanguageSelect" data-initial-locale="<?= Helpers::sanitize($activeLocale) ?>">
+                                        <?php foreach ($languageOptions as $option): ?>
+                                            <option value="<?= Helpers::sanitize($option['code']) ?>" <?= $option['code'] === $activeLocale ? 'selected' : '' ?>>
+                                                <?= Helpers::sanitize($option['label']) ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                            <?php endif; ?>
+                            <?php if ($showBalanceInfo): ?>
+                                <div class="navbar-balance text-white-50 text-lg-end">
+                                    <div class="navbar-balance-label text-uppercase small"><?= Helpers::sanitize('Bakiye') ?></div>
+                                    <div class="navbar-balance-amount fw-semibold text-white"><?= $userBalanceHtml ?></div>
+                                </div>
+                            <?php endif; ?>
+                            <div class="dropdown navbar-profile-dropdown">
+                                <button class="btn btn-navbar-profile dropdown-toggle" type="button" id="navbarProfileDropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false">
+                                    <?php if ($userAvatarUrl !== ''): ?>
+                                        <img src="<?= Helpers::sanitize($userAvatarUrl) ?>" alt="<?= Helpers::sanitize($userDisplayName) ?>" class="navbar-avatar-image rounded-circle" width="36" height="36">
+                                    <?php else: ?>
+                                        <span class="navbar-avatar-initial"><?= Helpers::sanitize($avatarInitial) ?></span>
+                                    <?php endif; ?>
+                                    <span class="fw-semibold d-none d-sm-inline"><?= Helpers::sanitize($userDisplayName) ?></span>
+                                </button>
+                                <ul class="dropdown-menu dropdown-menu-end shadow-sm border-0 rounded-3 mt-2" aria-labelledby="navbarProfileDropdown" role="menu">
+                                    <li class="px-3 pt-2 pb-1 text-white-50 small"><?= Helpers::sanitize('Hoş geldin') ?> <?= Helpers::sanitize($userDisplayName) ?>!</li>
+                                    <li class="px-3 pb-2 text-white-50 small"><?= Helpers::sanitize($userRoleLabel) ?></li>
+                                    <?php if ($showBalanceInfo): ?>
+                                        <li><hr class="dropdown-divider my-2"></li>
+                                        <li class="px-3 pb-2 text-white-50 small"><?= Helpers::sanitize('Kredi') ?>: <span class="text-white fw-semibold"><?= $userBalanceHtml ?></span></li>
+                                    <?php endif; ?>
+                                    <li><hr class="dropdown-divider my-2"></li>
+                                    <li><a class="dropdown-item" href="/profile.php"><i class="bi bi-person-circle me-2"></i><?= Helpers::sanitize('Profil') ?></a></li>
+                                    <li><a class="dropdown-item" href="<?= $isAdminRole ? '/admin/balances.php' : '/balance.php' ?>"><i class="bi bi-receipt me-2"></i><?= Helpers::sanitize('Mali Geçmiş') ?></a></li>
+                                    <?php if (Helpers::featureEnabled('balance')): ?>
+                                        <li><a class="dropdown-item" href="<?= Helpers::featureEnabled('balance') ? '/balance.php' : '#' ?>"><i class="bi bi-plus-circle me-2"></i><?= Helpers::sanitize('Kredi Ekle') ?></a></li>
+                                    <?php endif; ?>
+                                    <li><hr class="dropdown-divider my-2"></li>
+                                    <li><a class="dropdown-item text-danger" href="/logout.php"><i class="bi bi-box-arrow-right me-2"></i><?= Helpers::sanitize('Çıkış Yap') ?></a></li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
-            <nav class="sidebar-nav" id="sidebarNav">
-                <?php foreach ($menuSections as $section): ?>
-                    <div class="sidebar-section">
-                        <div class="sidebar-section-heading text-uppercase text-white-75 small fw-semibold">
-                            <?= Helpers::sanitize($section['heading']) ?>
-                        </div>
-                        <ul class="list-unstyled mb-0 sidebar-section-list">
-                            <?php foreach ($section['items'] as $navItem): ?>
-                                <?php $itemActive = Helpers::isActive($navItem['pattern']); ?>
-                                <li>
-                                    <a href="<?= $navItem['href'] ?>" class="sidebar-link <?= $itemActive ? 'active' : '' ?>">
-                                        <?php if (!empty($navItem['icon'])): ?>
-                                            <span class="sidebar-link-icon"><i class="<?= Helpers::sanitize($navItem['icon']) ?>"></i></span>
-                                        <?php endif; ?>
-                                        <span class="sidebar-link-text"><?= Helpers::sanitize($navItem['label']) ?></span>
-                                        <?php if (!empty($navItem['badge']) && (int) $navItem['badge'] > 0): ?>
-                                            <span class="sidebar-link-badge"><?= (int) $navItem['badge'] ?></span>
-                                        <?php endif; ?>
-                                    </a>
-                                </li>
-                            <?php endforeach; ?>
-                        </ul>
-                    </div>
-                <?php endforeach; ?>
-            </nav>
-            <div class="sidebar-footer mt-auto">
-                <a href="/logout.php" class="btn btn-outline-light w-100"><i class="bi bi-box-arrow-right me-2"></i><?= Helpers::sanitize('Çıkış Yap') ?></a>
-            </div>
-        </aside>
-        <div class="sidebar-backdrop d-lg-none" data-sidebar-close></div>
+        </header>
     <?php endif; ?>
     <div class="app-main d-flex flex-column flex-grow-1">
         <?php if ($user): ?>
-            <header class="app-topbar d-flex align-items-center justify-content-between gap-3 flex-wrap">
-                <div class="d-flex align-items-center gap-3">
-                    <button class="sidebar-toggle btn btn-light border-0 d-lg-none" type="button" data-sidebar-toggle aria-controls="appSidebar" aria-expanded="false" aria-label="<?= Helpers::sanitize('Menüyü Aç') ?>">
-                        <i class="bi bi-list"></i>
-                    </button>
+            <header class="app-topbar">
+                <div class="app-topbar-inner d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
                     <div>
                         <h1 class="h4 mb-1"><?= Helpers::sanitize($pageHeadline) ?></h1>
                         <p class="text-muted mb-0 small"><?= date('d F Y') ?></p>
                     </div>
                 </div>
-                <?php if ($hasTopbarActions): ?>
-                    <div class="app-topbar-actions d-flex align-items-center flex-wrap gap-3 ms-lg-auto">
-                        <?php if ($showLanguageSwitch): ?>
-                            <div class="app-language-switcher">
-                                <label class="form-label form-label-sm text-muted mb-1" for="appLanguageSelect"><?= Helpers::sanitize('Dil') ?></label>
-                                <select class="form-select form-select-sm" id="appLanguageSelect" data-initial-locale="<?= Helpers::sanitize($activeLocale) ?>">
-                                    <?php foreach ($languageOptions as $option): ?>
-                                        <option value="<?= Helpers::sanitize($option['code']) ?>" <?= $option['code'] === $activeLocale ? 'selected' : '' ?>>
-                                            <?= Helpers::sanitize($option['label']) ?>
-                                        </option>
-                                    <?php endforeach; ?>
-                                </select>
-                            </div>
-                        <?php endif; ?>
-                    </div>
-                <?php endif; ?>
             </header>
         <?php else: ?>
             <header class="app-topbar app-topbar--guest shadow-sm">


### PR DESCRIPTION
## Summary
- restructure the shared header to keep the logo fixed left, move the navigation immediately beside it, and tuck utilities inside the collapse for mobile layouts
- tweak navbar styling so menus stack vertically on small screens while the right-side controls stay aligned and visible on larger viewports

## Testing
- php -l templates/header.php

------
https://chatgpt.com/codex/tasks/task_b_68e52a82fef08321a0e59cf56e32f599